### PR TITLE
#60 farbiger manövertext

### DIFF
--- a/scripts/sheets/dialogs/combat_dialog.js
+++ b/scripts/sheets/dialogs/combat_dialog.js
@@ -43,6 +43,51 @@ export class CombatDialog extends Dialog {
             })
             item.classList.toggle('has-value', hasValue)
         })
+
+        // Colorize numbers in maneuver labels
+        this.colorizeManeuverNumbers(html)
+    }
+
+    colorizeManeuverNumbers(html) {
+        // Apply to both maneuver labels and other labels in the dialog
+        html.find('.maneuver-item label, .flexrow label').each((index, label) => {
+            let text = label.textContent
+
+            // Find all parentheses content
+            text = text.replace(/(\([^)]+\))/g, (parenthesesContent) => {
+                // Count positive and negative numbers/variables in this parentheses
+                const positiveMatches = (parenthesesContent.match(/\+\s*(\d+|[A-Z]+)/g) || [])
+                    .length
+                const negativeMatches = (parenthesesContent.match(/\-\s*(\d+|[A-Z]+)/g) || [])
+                    .length
+
+                // Determine dominant color
+                let dominantClass = ''
+                if (negativeMatches > positiveMatches) {
+                    dominantClass = 'maneuver-negative'
+                } else if (positiveMatches > negativeMatches) {
+                    dominantClass = 'maneuver-positive'
+                }
+
+                // Make the entire parentheses bold and colored
+                if (dominantClass) {
+                    return `<strong class="${dominantClass}">${parenthesesContent}</strong>`
+                } else {
+                    return `<strong>${parenthesesContent}</strong>`
+                }
+            })
+
+            // Handle numbers/variables outside of parentheses
+            text = text.replace(/([\+\-]\s*(\d+|[A-Z]+))(?![^<]*<\/strong>)/g, (match) => {
+                const isPositive = match.includes('+')
+                const cssClass = isPositive ? 'maneuver-positive' : 'maneuver-negative'
+                return `<span class="${cssClass}">${match}</span>`
+            })
+
+            if (text !== label.textContent) {
+                label.innerHTML = text
+            }
+        })
     }
 
     aufbauendeManoeverAktivieren() {

--- a/styles/sheets/manoever.css
+++ b/styles/sheets/manoever.css
@@ -359,6 +359,17 @@
   border-bottom-color: #006400;
 }
 
+/* Positive and negative number styling for maneuver labels and inputs */
+.maneuver-positive,
+input.maneuver-positive {
+  color: #006400 !important; /* Dark green */
+}
+
+.maneuver-negative,
+input.maneuver-negative {
+  color: #8b0000 !important; /* Dark red */
+}
+
 .damage-summary h4 {
   color: #cc4400;
   border-bottom-color: #cc4400;


### PR DESCRIPTION
hab das mal umgesetzt, passt so oder soll was anders?
alles mit + drin wird grün
alles mit . drin wird rot
mit beidem drin bleibt schwarz (glaube nur bei volle offensive)
alles in fett für bessere sichtbarkeit
