### PR TITLE
Fix/bug fixes

### DIFF
--- a/css/temp.css
+++ b/css/temp.css
@@ -555,3 +555,169 @@ input[type="number"]::-webkit-inner-spin-button {
   color: #cc4400 !important;
   text-shadow: 0 0 3px rgba(204, 68, 0, 0.5);
 }
+
+.kreatur-sheet input {
+  border: none;
+}
+
+.ilaris .titel-input {
+  font-size: 32px;
+  border: None;
+  color: rgb(83, 0, 0);
+  font-family: var(--font-andada);
+}
+
+input.titel-input {
+  font-size: 32px;
+  color: rgb(83, 0, 0);
+  font-family: var(--font-andada);
+}
+
+.kreatur-sheet .plus-button {
+  color: rgb(54, 37, 37);
+  font-size: 18px;
+}
+
+.attributblock h2 {
+  font-family: var(--font-aniron);
+  font-size: 14px;
+  color: rgb(54, 37, 37); /*rgb(83, 0, 0);*/
+  border: none;
+}
+
+.kreatur-header textarea {
+  border: none;
+  resize: none;
+  font-family: var(--font-crimson);
+}
+
+.statblockreihe {
+  background-color: rgba(247, 68, 37, 0.13);
+  padding: 10px;
+  border-top: solid darkred 2px;
+}
+
+.statblockreihe input {
+  width: 40px;
+  height: 16px;
+  background: rgba(250, 250, 250, 0.2);
+}
+
+/* --------------------------------------- */
+/*  Ilaris Sheet                           */
+/* --------------------------------------- */
+.ilaris {
+  min-width: 360px;
+  min-height: 320px;
+}
+.ilaris form > * {
+  flex: 0;
+}
+.ilaris .form-group.description {
+  flex: 1;
+}
+.ilaris .form-group.description label {
+  height: 24px;
+}
+.ilaris .form-group.description textarea {
+  height: calc(100% - 24px);
+  resize: none;
+}
+
+.validation-icon {
+  font-size: 1.2em;
+  flex: 0;
+  margin-left: 16px;
+}
+
+.maximum-load-exceeded-left,
+.maximum-load-exceeded-middle,
+.maximum-load-exceeded-right {
+  border: red;
+  border-style: solid;
+}
+.maximum-load-exceeded-left {
+  border-width: 3px 0 3px 3px;
+}
+.maximum-load-exceeded-middle {
+  border-width: 3px 0 3px 0;
+}
+.maximum-load-exceeded-right {
+  border-width: 3px 3px 3px 0;
+}
+
+.flexrow {
+  margin: 4px 0;
+  align-items: center;
+}
+
+.flexrow .label {
+  min-width: 150px;
+}
+
+put[type='text']:focus,
+input[type='number']:focus,
+select:focus,
+textarea:focus {
+  border-color: #782e22;
+  box-shadow: 0 0 3px rgba(120, 46, 34, 0.3);
+}
+
+hr {
+  margin: 16px 0;
+  border: 0;
+  border-top: 1px solid #353535;
+}
+
+.system-pack {
+  font-weight: bold;
+  font-size: 1.2em;
+  color: #782e22; /* Using the same red color as in manoever.css */
+}
+
+.system-pack input[type='checkbox'] {
+  transform: scale(1.2); /* Make the checkbox slightly bigger too */
+  margin-right: 10px; /* Add some space after the bigger checkbox */
+}
+
+.pack-entry {
+  margin-bottom: 4px;
+}
+
+.pack-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.checkbox.disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.checkbox.disabled input[type='checkbox'] {
+  cursor: not-allowed;
+}
+
+.disabled-reason {
+  font-style: italic;
+  color: #782e22;
+  font-size: 0.9em;
+}
+
+.error-highlight {
+  color: #ff0000;
+  text-decoration: underline wavy #ff0000;
+  cursor: help;
+}
+
+.notes {
+  white-space: pre-line;
+}

--- a/css/temp.css
+++ b/css/temp.css
@@ -451,9 +451,26 @@ input[name="name"] {
   border-width: 2px;
 }
 
+.regex-check:valid + .validation-icon::before {
+  content: '✔';
+  color: green;
+}
+
+/* Style for valid input */
+.regex-check:valid {
+  border-color: green;
+  border-width: 2px;
+}
+
 .regex-check:invalid + .validation-icon::before {
   content: '✘';
   color: red;
+}
+
+/* Style for invalid input */
+.regex-check:invalid {
+  border-color: red;
+  border-width: 2px;
 }
 
 .multi-select {
@@ -489,4 +506,52 @@ input[type="number"]::-webkit-inner-spin-button {
   appearance: auto !important;
   margin: 0 !important;
   display: inline-block !important;
+}
+
+/* Clickable Summary Sections */
+.clickable-summary {
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border: 2px solid transparent;
+  border-radius: 5px;
+  margin-bottom: 10px;
+}
+
+.clickable-summary:hover {
+  transform: translateY(-1px);
+}
+
+.clickable-summary h4 {
+  cursor: pointer;
+  font-weight: bold;
+}
+
+.clickable-summary.angreifen:hover {
+  border-color: #8b0000;
+  box-shadow: 0 0 8px rgba(139, 0, 0, 0.3);
+}
+
+.clickable-summary.angreifen:hover h4 {
+  color: #8b0000 !important;
+  text-shadow: 0 0 3px rgba(139, 0, 0, 0.5);
+}
+
+.clickable-summary.verteidigen:hover {
+  border-color: #006400;
+  box-shadow: 0 0 8px rgba(0, 100, 0, 0.3);
+}
+
+.clickable-summary.verteidigen:hover h4 {
+  color: #006400 !important;
+  text-shadow: 0 0 3px rgba(0, 100, 0, 0.5);
+}
+
+.clickable-summary.schaden:hover {
+  border-color: #cc4400;
+  box-shadow: 0 0 8px rgba(204, 68, 0, 0.3);
+}
+
+.clickable-summary.schaden:hover h4 {
+  color: #cc4400 !important;
+  text-shadow: 0 0 3px rgba(204, 68, 0, 0.5);
 }

--- a/scripts/actors/actor.js
+++ b/scripts/actors/actor.js
@@ -383,7 +383,11 @@ export class IlarisActor extends Actor {
         asp += Number(actor.system.abgeleitete.asp_zugekauft) || 0
         asp -= Number(actor.system.abgeleitete.gasp) || 0
         actor.system.abgeleitete.asp = asp
-        actor.system.abgeleitete.asp_stern = Number(actor.system.abgeleitete.asp_stern) || asp
+        actor.system.abgeleitete.asp_stern =
+            actor.system.abgeleitete.asp_stern !== null &&
+            actor.system.abgeleitete.asp_stern !== undefined
+                ? Number(actor.system.abgeleitete.asp_stern)
+                : asp
         // let kap = 0;
         // kap = hardcoded.geweihter(kap, data);
         let kap = hardcoded.geweihter(actor)
@@ -391,7 +395,11 @@ export class IlarisActor extends Actor {
         kap += Number(actor.system.abgeleitete.kap_zugekauft) || 0
         kap -= Number(actor.system.abgeleitete.gkap) || 0
         actor.system.abgeleitete.kap = kap
-        actor.system.abgeleitete.kap_stern = Number(actor.system.abgeleitete.kap_stern) || kap
+        actor.system.abgeleitete.kap_stern =
+            actor.system.abgeleitete.kap_stern !== null &&
+            actor.system.abgeleitete.kap_stern !== undefined
+                ? Number(actor.system.abgeleitete.kap_stern)
+                : kap
     }
 
     async _calculateKampf(actor) {

--- a/scripts/sheets/dialogs/uebernatuerlich.js
+++ b/scripts/sheets/dialogs/uebernatuerlich.js
@@ -93,14 +93,7 @@ export class UebernatuerlichDialog extends CombatDialog {
         // Initialize and check energy values
         await this.initializeEnergyValues()
 
-        // If not enough resources, show erro
-        if (this.currentEnergy < this.mod_energy) {
-            ui.notifications.error(
-                `Nicht genug Ressourcen! Benötigt: ${this.mod_energy}, Vorhanden: ${this.currentEnergy}. Unter bestimmten Voraussetzungen zieht dir das System einfach Energie ab, bis du bei 0 angelangt bist. Du kannst diese Information nach eigenem Ermessen weiterverwenden.`,
-            )
-        }
-
-        let label = `${this.item.name} (Gesamt Kosten: ${this.mod_energy} Energie (das sind noch nicht die endgültigen Kosten des Zaubers))`
+        let label = `${this.item.name}`
         let formula = `${diceFormula} ${signed(this.item.system.pw)} \
             ${signed(this.at_abzuege_mod)} \
             ${signed(this.mod_at)}`
@@ -135,6 +128,12 @@ export class UebernatuerlichDialog extends CombatDialog {
         this.is16OrHigher = is16OrHigher
         if (difficulty) {
             await this.applyEnergyCost(isSuccess, is16OrHigher)
+            // If not enough resources, show erro
+            if (this.currentEnergy < this.endCost) {
+                ui.notifications.error(
+                    `Nicht genug Ressourcen! Benötigt: ${this.endCost}, Vorhanden: ${this.currentEnergy}. Unter bestimmten Voraussetzungen zieht dir das System einfach Energie ab, bis du bei 0 angelangt bist. Du kannst diese Information nach eigenem Ermessen weiterverwenden.`,
+                )
+            }
         }
         super._updateSchipsStern(html)
     }

--- a/templates/sheets/dialogs/uebernatuerlich.hbs
+++ b/templates/sheets/dialogs/uebernatuerlich.hbs
@@ -63,7 +63,6 @@
         style="margin-right: 10px"
     />
 </div>
-<div class="description">Wähle aus wie viel AsP pro Wunde du erhältst.</div>
 {{/if}} {{#if canSetEnergyCost}}
 <div class="flexrow">
     <label>Basisenergiekosten (frei wählbar):</label>
@@ -74,7 +73,7 @@
         placeholder="Energie frei setzen"
     />
 </div>
-<div class="description">Mit diesem Feld kannst du die Basisenergiekosten nach Belieben festlegen. Gedacht für den Unitatio (und dadurch ist dieses Feld erst verfügbar), weil der Vorteil eher mäßig gut umsetzbar ist.</div>
+<div class="description">Mit diesem Feld kannst du die Basisenergiekosten nach Belieben festlegen.</div>
 {{/if}}
 <hr />
 

--- a/templates/sheets/items/angriff.hbs
+++ b/templates/sheets/items/angriff.hbs
@@ -48,7 +48,7 @@
                 <div class="flexrow">
                     <input
                         class="regex-check"
-                        pattern="^\\\\\\\\\\d+[WwDd]\d{1,2}([\+\-]?\d*)?$"
+                        pattern="^\d+[WwDd]\d{1,2}([\+\-]?\d*)?$"
                         title="TP der Waffe in Schema xWy+/-z Anzahl Würfel x, Würfelkürzel W,w,D oder d, Seitenanzahl y, +/- Modifikator und Modifikator z"
                         type="text"
                         name="system.tp"

--- a/templates/sheets/items/fernkampfwaffe.hbs
+++ b/templates/sheets/items/fernkampfwaffe.hbs
@@ -16,7 +16,7 @@
                 <label class="flex-fest-var" style="flex-basis: 100px"><b>Schaden:</b></label>
                 <input
                     class="regex-check"
-                    pattern="^\\\\\\\\\\d+[WwDd]\d{1,2}([\+\-]?\d*)?$"
+                    pattern="^\d+[WwDd]\d{1,2}([\+\-]?\d*)?$"
                     title="TP der Waffe in Schema xWy+/-z Anzahl Würfel x, Würfelkürzel W,w,D oder d, Seitenanzahl y, +/- Modifikator und Modifikator z"
                     type="text"
                     name="system.tp"

--- a/templates/sheets/items/nahkampfwaffe.hbs
+++ b/templates/sheets/items/nahkampfwaffe.hbs
@@ -16,7 +16,7 @@
                 <label class="flex-fest-var" style="flex-basis: 100px"><b>Schaden:</b></label>
                 <input
                     class="regex-check"
-                    pattern="^\\\\\\\\d+[WwDd]\d{1,2}([\+\-]?\d*)?$"
+                    pattern="^\d+[WwDd]\d{1,2}([\+\-]?\d*)?$"
                     title="TP der Waffe in Schema xWy+/-z Anzahl Würfel x, Würfelkürzel W,w,D oder d, Seitenanzahl y, +/- Modifikator und Modifikator z"
                     type="text"
                     name="system.tp"


### PR DESCRIPTION
Bug fixes + viele styling fixes
Würfeldialog Magie:
Der Erkärtext bei Basiskosten frei wählen ist mMn redundant und etwas unprofessionell.
Ich würde die Basiskosten frei wählen Option außerdem nicht hinter dem Unitatio verstecken. Auf 0 setzen kann nützlich sein für z.B Blutmagie und man braucht das Feld für Zauber mit Variablen Kosten (Invocatio z.B.).
"Wähle aus wie viel AsP du pro Wunde erhälst" - redundant mit der neuen Auswahl WS+4 oder WS+8?
Chatausgabe: zu viel im Titel und was heißt: "Das sind noch nicht die endgüliten Kosten des Zaubers" Kann das gestrichen werdne? "Gesamt Kosten: X AsP" - brauchen wir das und wenn ja im Titel? (Es gibt ja noch die Ausgabe danach, die sagt wie viel abgezogen wird.)
Wenn ich mich leer Zaubere (also unter 0 AsP fallen würde), werden meine AsP auf voll gesetzt. (Ich hatte mich glaube ich mal dagegen ausgesprochen Zauber bei zu wenig AsP zu verbieten. Jetzt mit dem Basiskosten frei wählbar Feld könnte man es doch wieder einführen, weil man auf das 0 setzen kann für Spezialfälle. Oder? So würde sich dieses Problem jedenfalls erledigen. Sorry fürs hin- und her)
Ich glaube Basiskosten frei wählen hat bei mir nicht funktioniert, aber jetzt wurde gerade der Testserver abgeschaltet und bei meinem lokalen Setup kann ich den Magie-Würfeldialog im aktuellen Stand nicht klicken 😄


Würfeldialog Kampf:
Die Buttons rechts sind nicht mehr Sichtbar Unterteilt und beim Hovern nicht als klickbar ersichtlich.