### PR TITLE
feat(99): ability to tab through char sheet

### DIFF
--- a/scripts/actors/templates/held/held-navigation.hbs
+++ b/scripts/actors/templates/held/held-navigation.hbs
@@ -1,4 +1,4 @@
-<nav class="sheet-tabs tabs herotabnavigation">
+<nav class="sheet-tabs tabs herotabnavigation" data-group="primary">
     <a data-action="tab" class="tab-item {{tabs.attribute.cssClass}}" data-group="primary" data-tab="attribute">
         <img class="round-icon" src="/systems/Ilaris/assets/images/Ilaris/attribute.webp" height="20" width="20" />
         <span>Attribute</span>

--- a/scripts/core/init.js
+++ b/scripts/core/init.js
@@ -36,6 +36,7 @@ import { registerDefenseButtonHook } from '../combat/dialogs/defense_button_hook
 import { XmlCharacterImporter } from '../importer/xml_character_importer.js'
 import { XMLRuleImporter } from '../importer/xml_rule_importer/index.js'
 import { formatDiceFormula } from './utilities.js'
+import { initializeKeybinds } from './keybinds.js'
 
 const Actors = foundry.documents.collections.Actors
 const Items = foundry.documents.collections.Items
@@ -116,6 +117,7 @@ Hooks.once('init', () => {
     })
 
     initializeHandlebars()
+    initializeKeybinds()
     // game.sephrasto = new SephrastoImporter();
     CONFIG.ILARIS = ILARIS
     CONFIG.Combat.initiative = { formula: '@initiative', decimals: 1 }

--- a/scripts/core/keybinds.js
+++ b/scripts/core/keybinds.js
@@ -1,0 +1,64 @@
+export function initializeKeybinds() {
+    registerNewKeybinds()
+}
+
+function registerNewKeybinds() {
+    registerHeldTabbing()
+}
+
+// TAB keybind to rotate through "Held" sheet tabs with TAB key
+function registerHeldTabbing() {
+    // NOTE: Would be nice to block the default TAB core.cycleView behaviour
+    // When a Actor sheet for Ilaris is open
+    game.keybindings.register('Ilaris', 'rotateInHeldSheet', {
+        name: 'Held Tabs rotieren',
+        hint: 'Rotiere durch die Tabs im Heldenbogen.',
+        uneditable: [],
+        namespace: 'Ilaris',
+        editable: [
+            {
+                key: 'Tab',
+            },
+        ],
+        reservedModifiers: ['SHIFT'],
+        repeat: true,
+        onDown: (ctx) => {
+            const heldTab = document.getElementsByClassName('herotabnavigation')
+
+            if (heldTab.length == 0) {
+                // If Held sheet is closed - do nothing
+                return
+            }
+            // Risky lookup of actor sheet ID based on code structure
+            const actorId = heldTab[0].parentNode.parentNode.id.split('-')[2]
+            const actor = game.actors.get(actorId)
+
+            // Set Tab to next Tab in Tab view
+            const childElements = heldTab[0].children
+            const totalTabs = childElements.length
+            let activeIndex = 0
+            Array.from(childElements).forEach((child, i) => {
+                if (child.classList.contains('active')) {
+                    activeIndex = i
+                }
+            })
+
+            let nextTab = activeIndex + 1
+            if (nextTab > totalTabs - 1) {
+                nextTab = 0
+            }
+            // Reverse with Shift clicked
+            if (ctx.isShift) {
+                let previousTab = activeIndex - 1
+                if (previousTab < 0) {
+                    previousTab = totalTabs - 1
+                }
+                nextTab = previousTab
+            }
+            actor._sheet.changeTab(childElements[nextTab].dataset.tab, 'primary')
+            // Maybe if shift used - go left
+        },
+        onUp: () => {},
+        precedence: CONST.KEYBINDING_PRECEDENCE.NORMAL,
+    })
+}


### PR DESCRIPTION
Base on a misunderstanding of #99 but considered as a cool effect, it's possible now to rotate between the Tabs in the character sheet by using TAB.

Buggy behaviour, if there are multiple actors assigned to the player, it cycles through them based on default foundry behaviour as well.

Nice combination though with only keyboard.
`C` to open your character sheet, `TAB` to go through the tabs, `ESC` to close it again