### PR TITLE
feat(99): improve autofocus keyboard support

### DIFF
--- a/scripts/combat/templates/dialogs/angriff.hbs
+++ b/scripts/combat/templates/dialogs/angriff.hbs
@@ -8,7 +8,7 @@
             {{#if actor.system.schips.schips_stern}}
             <label>
                 <input type="radio" name="schips-{{dialogId}}" value="0" {{#if (ifEq checked_schips
-                "0")}}checked{{/if}} /> Kein Schips
+                "0")}}checked{{/if}} autofocus /> Kein Schips
             </label>
             <label>
                 <input type="radio" name="schips-{{dialogId}}" value="1" {{#if (ifEq checked_schips

--- a/scripts/combat/templates/dialogs/fernkampf_angriff.hbs
+++ b/scripts/combat/templates/dialogs/fernkampf_angriff.hbs
@@ -9,7 +9,7 @@
             {{#if actor.system.schips.schips_stern}}
             <label>
                 <input type="radio" name="schips-{{dialogId}}" value="0" {{#if (ifEq checked_schips
-                "0")}}checked{{/if}} /> Kein Schips
+                "0")}}checked{{/if}} autofocus /> Kein Schips
             </label>
             <label>
                 <input type="radio" name="schips-{{dialogId}}" value="1" {{#if (ifEq checked_schips

--- a/scripts/combat/templates/dialogs/uebernatuerlich.hbs
+++ b/scripts/combat/templates/dialogs/uebernatuerlich.hbs
@@ -14,7 +14,7 @@
                 {{#if actor.system.schips.schips_stern}}
                 <label>
                     <input type="radio" name="schips-{{dialogId}}" value="0" {{#if (ifEq checked_schips
-                    "0")}}checked{{/if}} /> Kein Schips
+                    "0")}}checked{{/if}} autofocus /> Kein Schips
                 </label>
                 <label>
                     <input type="radio" name="schips-{{dialogId}}" value="1" {{#if (ifEq checked_schips

--- a/scripts/items/templates/abgeleiteter-wert.hbs
+++ b/scripts/items/templates/abgeleiteter-wert.hbs
@@ -5,7 +5,13 @@
             <header class="sheet-header">
                 <div class="header-fields">
                     <h1 class="charname">
-                        <input name="name" type="text" value="{{item.name}}" placeholder="Interner Name (z.B. WS, MR, INI)" />
+                        <input
+                            name="name"
+                            type="text"
+                            value="{{item.name}}"
+                            placeholder="Interner Name (z.B. WS, MR, INI)"
+                            autofocus
+                        />
                     </h1>
                 </div>
             </header>

--- a/scripts/items/templates/angriff.hbs
+++ b/scripts/items/templates/angriff.hbs
@@ -5,7 +5,7 @@
             <header class="sheet-header">
                 <div class="header-fields">
                     <h1 class="charname">
-                        <input name="name" type="text" value="{{item.name}}" />
+                        <input name="name" type="text" value="{{item.name}}" autofocus />
                     </h1>
                 </div>
             </header>

--- a/scripts/items/templates/effect-item.hbs
+++ b/scripts/items/templates/effect-item.hbs
@@ -7,7 +7,13 @@
         
         <div class="header-fields">
             <h1 class="charname">
-                <input name="name" type="text" value="{{item.name}}" placeholder="Effect Container Name"/>
+                <input
+                    name="name"
+                    type="text"
+                    value="{{item.name}}"
+                    placeholder="Effect Container Name"
+                    autofocus
+                />
             </h1>
             
             <div class="resource">

--- a/scripts/items/templates/eigenheit.hbs
+++ b/scripts/items/templates/eigenheit.hbs
@@ -1,6 +1,6 @@
 {{log 'eigenheit' this}}
 <section class="{{cssClass}}">
     <div>
-        <textarea rows="8" name="system.text">{{item.system.text}}</textarea>
+        <textarea rows="8" name="system.text" autofocus>{{item.system.text}}</textarea>
     </div>
 </section>

--- a/scripts/items/templates/eigenschaft.hbs
+++ b/scripts/items/templates/eigenschaft.hbs
@@ -1,7 +1,7 @@
 {{log 'eigenschaft' this}}
 <section class="{{cssClass}}">
     <div>
-        <input class="titel-input" name="name" type="text" value="{{item.name}}" />
+        <input class="titel-input" name="name" type="text" value="{{item.name}}" autofocus />
         <hr />
         <label>Beschreibung:</label>
         <textarea rows="8" name="system.text">{{item.system.text}}</textarea>

--- a/scripts/items/templates/fertigkeit.hbs
+++ b/scripts/items/templates/fertigkeit.hbs
@@ -3,7 +3,14 @@
     <header class="sheet-header">
         <img class="profile-img" src="{{item.img}}" data-action="editImage" data-edit="img" title="{{item.name}}" />
         <div class="header-fields">
-            <h1 class="charname"><input name="name" type="text" value="{{item.name}}" /></h1>
+            <h1 class="charname">
+                <input
+                    name="name"
+                    type="text"
+                    value="{{item.name}}"
+                    autofocus
+                />
+            </h1>
         </div>
     </header>
 

--- a/scripts/items/templates/freie_fertigkeit.hbs
+++ b/scripts/items/templates/freie_fertigkeit.hbs
@@ -5,7 +5,7 @@
             <header class="sheet-header">
                 <div class="header-fields">
                     <h1 class="charname">
-                        <input name="name" type="text" value="{{item.name}}" />
+                        <input name="name" type="text" value="{{item.name}}" autofocus />
                     </h1>
                 </div>
             </header>

--- a/scripts/items/templates/freies_talent.hbs
+++ b/scripts/items/templates/freies_talent.hbs
@@ -3,7 +3,7 @@
     <div class="flexrow">
         <div>
             <label>Freies Talent:</label>
-            <input name="name" type="text" value="{{item.name}}" />
+            <input name="name" type="text" value="{{item.name}}" autofocus />
         </div>
         <div>
             <label>Probenwert:</label>

--- a/scripts/items/templates/gegenstand.hbs
+++ b/scripts/items/templates/gegenstand.hbs
@@ -5,7 +5,7 @@
             <header class="sheet-header">
                 <div class="header-fields">
                     <h1 class="charname">
-                        <input name="name" type="text" value="{{item.name}}" />
+                        <input name="name" type="text" value="{{item.name}}" autofocus />
                     </h1>
                 </div>
             </header>

--- a/scripts/items/templates/info.hbs
+++ b/scripts/items/templates/info.hbs
@@ -5,7 +5,7 @@
             <header class="sheet-header">
                 <div class="header-fields">
                     <h1 class="charname">
-                        <input name="name" type="text" value="{{item.name}}" />
+                        <input name="name" type="text" value="{{item.name}}" autofocus />
                     </h1>
                 </div>
             </header>

--- a/scripts/items/templates/manoever.hbs
+++ b/scripts/items/templates/manoever.hbs
@@ -9,6 +9,7 @@
                         type="text"
                         value="{{item.name}}"
                         placeholder="Manövername"
+                        autofocus
                     />
                 </h1>
             </div>

--- a/scripts/items/templates/ruestung.hbs
+++ b/scripts/items/templates/ruestung.hbs
@@ -6,7 +6,7 @@
                 <img class="profile-img" src="{{item.img}}" data-action="editImage" data-edit="img" title="{{item.name}}" />
                 <div class="header-fields">
                     <h1 class="charname">
-                        <input name="name" type="text" value="{{item.name}}" />
+                        <input name="name" type="text" value="{{item.name}}" autofocus />
                     </h1>
                 </div>
             </header>

--- a/scripts/items/templates/talent.hbs
+++ b/scripts/items/templates/talent.hbs
@@ -9,6 +9,7 @@
                 type="text"
                 value="{{item.name}}"
                 placeholder='{{localize "Talent"}}'
+                autofocus
             />
         </h1>
     </header>

--- a/scripts/items/templates/uebernatuerlich_fertigkeit.hbs
+++ b/scripts/items/templates/uebernatuerlich_fertigkeit.hbs
@@ -6,7 +6,7 @@
                 <img class="profile-img" src="{{item.img}}" data-action="editImage" data-edit="img" title="{{item.name}}" />
                 <div class="header-fields">
                     <h1 class="charname">
-                        <input name="name" type="text" value="{{item.name}}" />
+                        <input name="name" type="text" value="{{item.name}}" autofocus />
                     </h1>
                 </div>
             </header>

--- a/scripts/items/templates/uebernatuerlich_talent.hbs
+++ b/scripts/items/templates/uebernatuerlich_talent.hbs
@@ -5,7 +5,7 @@
             <header class="sheet-header">
                 <div class="header-fields">
                     <h1 class="charname">
-                        <input name="name" type="text" value="{{item.name}}" />
+                        <input name="name" type="text" value="{{item.name}}" autofocus />
                     </h1>
                 </div>
             </header>

--- a/scripts/items/templates/vorteil.hbs
+++ b/scripts/items/templates/vorteil.hbs
@@ -1,7 +1,7 @@
 {{log 'vorteil' this}}
 <section class="{{cssClass}}">
     <div>
-        <input class="titel-input" name="name" type="text" value="{{item.name}}" />
+        <input class="titel-input" name="name" type="text" value="{{item.name}}" autofocus />
         <hr />
         <div class="flexrow">
             <label><b>Kategorie:</b></label>

--- a/scripts/settings/templates/abgeleitete-werte-packs.hbs
+++ b/scripts/settings/templates/abgeleitete-werte-packs.hbs
@@ -9,8 +9,9 @@
         <div class="form-group pack-entry">
             <div class="pack-row">
                 <label class="checkbox">
-                    <input type="checkbox" name="{{this.id}}" {{#if this.selected}}checked{{/if}}>
-                    {{this.name}}
+                    <input type="checkbox" name="{{this.id}}" {{#if this.selected}}checked{{/if}} autofocus>
+                        {{this.name}}
+                    </input>
                 </label>
             </div>
         </div>

--- a/scripts/settings/templates/fertigkeiten-packs.hbs
+++ b/scripts/settings/templates/fertigkeiten-packs.hbs
@@ -5,8 +5,9 @@
         <div class="form-group pack-entry">
             <div class="pack-row">
                 <label class="checkbox">
-                    <input type="checkbox" name="{{this.id}}" {{#if this.selected}}checked{{/if}}>
-                    {{this.name}}
+                    <input type="checkbox" name="{{this.id}}" {{#if this.selected}}checked{{/if}} autofocus>
+                        {{this.name}}
+                    </input>
                 </label>
             </div>
         </div>

--- a/scripts/settings/templates/maneuver-packs.hbs
+++ b/scripts/settings/templates/maneuver-packs.hbs
@@ -8,9 +8,11 @@
                     class="checkbox {{#if (eq this.id 'Ilaris.manover')}}system-pack{{/if}} {{#if this.disabled}}disabled{{/if}}"
                 >
                     <input type="checkbox" name="{{this.id}}" {{#if this.selected}}checked{{/if}}
-                    {{#if this.disabled}}disabled title="{{this.disabledReason}}"{{/if}}> {{#if (eq
-                    this.id 'Ilaris.manover')}} {{this.name}} von Ilaris {{else}} {{this.name}}
-                    {{/if}}
+                    {{#if this.disabled}}disabled title="{{this.disabledReason}}"{{/if}} autofocus>
+                        {{#if (eq this.id 'Ilaris.manover')}}
+                            {{this.name}} von Ilaris {{else}} {{this.name}}
+                        {{/if}}
+                    </input>
                 </label>
                 {{#if this.disabled}}
                 <span class="disabled-reason">({{this.disabledReason}})</span>

--- a/scripts/settings/templates/talente-packs.hbs
+++ b/scripts/settings/templates/talente-packs.hbs
@@ -5,8 +5,14 @@
         <div class="form-group pack-entry">
             <div class="pack-row">
                 <label class="checkbox">
-                    <input type="checkbox" name="{{this.id}}" {{#if this.selected}}checked{{/if}}>
+                    <input
+                        type="checkbox"
+                        name="{{this.id}}"
+                        {{#if this.selected}}checked{{/if}}
+                        autofocus
+                    >
                     {{this.name}}
+                    </input>
                 </label>
             </div>
         </div>

--- a/scripts/settings/templates/vorteile-packs.hbs
+++ b/scripts/settings/templates/vorteile-packs.hbs
@@ -8,9 +8,11 @@
                     class="checkbox {{#if (eq this.id 'Ilaris.vorteile')}}system-pack{{/if}} {{#if this.disabled}}disabled{{/if}}"
                 >
                     <input type="checkbox" name="{{this.id}}" {{#if this.selected}}checked{{/if}}
-                    {{#if this.disabled}}disabled title="{{this.disabledReason}}"{{/if}}> {{#if (eq
-                    this.id 'Ilaris.vorteile')}} {{this.name}} von Ilaris {{else}} {{this.name}}
-                    {{/if}}
+                    {{#if this.disabled}}disabled title="{{this.disabledReason}}"{{/if}} autofocus>
+                        {{#if (eq this.id 'Ilaris.vorteile')}}
+                            {{this.name}} von Ilaris {{else}} {{this.name}}
+                        {{/if}}
+                    </input>
                 </label>
                 {{#if this.disabled}}
                 <span class="disabled-reason">({{this.disabledReason}})</span>

--- a/scripts/settings/templates/waffen-packs.hbs
+++ b/scripts/settings/templates/waffen-packs.hbs
@@ -5,8 +5,14 @@
         <div class="form-group pack-entry">
             <div class="pack-row">
                 <label class="checkbox">
-                    <input type="checkbox" name="{{this.id}}" {{#if this.selected}}checked{{/if}}>
-                    {{this.name}}
+                    <input
+                        type="checkbox"
+                        name="{{this.id}}"
+                        {{#if this.selected}}checked{{/if}}
+                        autofocus
+                    >
+                        {{this.name}}
+                    </input>
                 </label>
             </div>
         </div>

--- a/scripts/settings/templates/waffeneigenschaften-packs.hbs
+++ b/scripts/settings/templates/waffeneigenschaften-packs.hbs
@@ -8,9 +8,11 @@
                     class="checkbox {{#if (eq this.id 'Ilaris.waffeneigenschaften')}}system-pack{{/if}} {{#if this.disabled}}disabled{{/if}}"
                 >
                     <input type="checkbox" name="{{this.id}}" {{#if this.selected}}checked{{/if}}
-                    {{#if this.disabled}}disabled title="{{this.disabledReason}}"{{/if}}> {{#if (eq
-                    this.id 'Ilaris.waffeneigenschaften')}} {{this.name}} von Ilaris {{else}} {{this.name}}
-                    {{/if}}
+                    {{#if this.disabled}}disabled title="{{this.disabledReason}}"{{/if}} autofocus>
+                        {{#if (eq this.id 'Ilaris.waffeneigenschaften')}}
+                            {{this.name}} von Ilaris {{else}} {{this.name}}
+                        {{/if}}
+                    </input>
                 </label>
                 {{#if this.disabled}}
                 <span class="disabled-reason">({{this.disabledReason}})</span>

--- a/scripts/skills/templates/dialogs/fertigkeit.hbs
+++ b/scripts/skills/templates/dialogs/fertigkeit.hbs
@@ -6,7 +6,8 @@
         <div>
             <label>Anzahl W20:</label>
             <label>
-                <input type="radio" name="xd20-{{dialogId}}" value="0" {{#if (ifEq checked_xd20 "0")}}checked{{/if}} /> 1W20
+                <input type="radio" name="xd20-{{dialogId}}" value="0" 
+                    {{#if (ifEq checked_xd20 "0")}}checked{{/if}} autofocus /> 1W20
             </label>
             <label>
                 <input type="radio" name="xd20-{{dialogId}}" value="1" {{#if (ifEq checked_xd20 "1")}}checked{{/if}} /> 3W20

--- a/scripts/waffe/templates/fernkampfwaffe.hbs
+++ b/scripts/waffe/templates/fernkampfwaffe.hbs
@@ -6,7 +6,7 @@
                 <img class="profile-img" src="{{item.img}}" data-action="editImage" data-edit="img" title="{{item.name}}" />
                 <div class="header-fields">
                     <h1 class="charname">
-                        <input name="name" type="text" value="{{item.name}}" />
+                        <input name="name" type="text" value="{{item.name}}" autofocus />
                     </h1>
                 </div>
             </header>

--- a/scripts/waffe/templates/nahkampfwaffe.hbs
+++ b/scripts/waffe/templates/nahkampfwaffe.hbs
@@ -6,7 +6,7 @@
                 <img class="profile-img" src="{{item.img}}" data-action="editImage" data-edit="img" title="{{item.name}}" />
                 <div class="header-fields">
                     <h1 class="charname">
-                        <input name="name" type="text" value="{{item.name}}" />
+                        <input name="name" type="text" value="{{item.name}}" autofocus />
                     </h1>
                 </div>
             </header>

--- a/scripts/waffe/templates/waffeneigenschaft.hbs
+++ b/scripts/waffe/templates/waffeneigenschaft.hbs
@@ -1,7 +1,7 @@
 {{log 'waffeneigenschaft' this}}
 <section class="{{cssClass}}">
     <div>
-        <input class="titel-input" name="name" type="text" value="{{item.name}}" />
+        <input class="titel-input" name="name" type="text" value="{{item.name}}" autofocus />
         <hr />
         
         <div class="flexrow">


### PR DESCRIPTION
When opening sub-windows, it should focus now the first element in the forms directly, so it can be tabbed through the following elements more easily.

Resolve #99 for now. There can be further improvement for keyboard handling, which will hopefully be targetted by #380 as well