### PR TITLE
feat: enable dice roll details

### DIFF
--- a/scripts/core/init.js
+++ b/scripts/core/init.js
@@ -1005,6 +1005,17 @@ Hooks.on('renderChatMessageHTML', (message, htmlDOM, data) => {
         }
     })
 
+    // Set all dice-tooltip to be expanded, to see the dice rolls directly
+    const showDiceRollInChat = game.settings.get(
+        ConfigureGameSettingsCategories.Ilaris,
+        IlarisGameSettingNames.showDiceRollInChat,
+    )
+    if (showDiceRollInChat) {
+        htmlDOM.querySelectorAll('.dice-roll').forEach((element) => {
+            element.classList.add('expanded')
+        })
+    }
+
     // Handle defense prompt message visibility
     const isDefensePrompt = message.flags?.Ilaris?.defensePrompt
     if (isDefensePrompt) {

--- a/scripts/dice/wuerfel.js
+++ b/scripts/dice/wuerfel.js
@@ -3,11 +3,9 @@ import { openSkillDialog } from '../skills/skills-api.js'
 import { roll_crit_message } from './wuerfel_misc.js'
 
 export async function wuerfelwurf(target, actor) {
-    console.log(target)
     let speaker = ChatMessage.getSpeaker({ actor: actor })
     let systemData = actor.system
     let rolltype = target.dataset.rolltype
-    console.log('ILARIS | wuerfelwurf triggered', target, rolltype)
     let nahkampfmod = systemData.modifikatoren.nahkampfmod
     let pw = 0
     let label = 'Probe'
@@ -21,7 +19,6 @@ export async function wuerfelwurf(target, actor) {
         await openCombatDialog(actor, item, 'ranged')
     } else if (rolltype == 'magie_diag' || rolltype == 'karma_diag') {
         let item = actor.items.get(target.dataset.itemid)
-        console.log('item', item)
         await openCombatDialog(actor, item, 'supernatural')
     } else if (rolltype == 'fertigkeit_diag') {
         // Unified skill/attribute dialog with preview
@@ -93,7 +90,6 @@ export async function wuerfelwurf(target, actor) {
                 dialogId: dialogId,
             },
         )
-        console.log('hier')
         await foundry.applications.api.DialogV2.wait({
             window: { title: label },
             content: html,

--- a/scripts/dice/wuerfel_misc.js
+++ b/scripts/dice/wuerfel_misc.js
@@ -233,9 +233,7 @@ export async function postRollToChat(rollResult, speaker, messageMode) {
 }
 
 export function calculate_diceschips(html, text, actor, dialogId = '') {
-    // let text = "";
     const xd20Name = dialogId ? `xd20-${dialogId}` : 'xd20'
-    console.log(xd20Name)
     const schipsName = dialogId ? `schips-${dialogId}` : 'schips'
 
     const xd20_check = html.querySelectorAll(`input[name='${xd20Name}']`)
@@ -243,7 +241,6 @@ export function calculate_diceschips(html, text, actor, dialogId = '') {
     for (const i of xd20_check) {
         if (i.checked) xd20 = i.value
     }
-    // console.log(xd20);
     const schips_check = html.querySelectorAll(`input[name='${schipsName}']`)
     let schips = 0
     for (const i of schips_check) {

--- a/scripts/settings/configure-game-settings.js
+++ b/scripts/settings/configure-game-settings.js
@@ -74,6 +74,17 @@ export const registerIlarisGameSettings = () => {
             requiresReload: true,
         },
         {
+            // Register showing dice roll directly in chat message (instead of result only)
+            settingsName: IlarisGameSettingNames.showDiceRollInChat,
+            name: 'Würfel details im Chat direkt anzeigen',
+            hint: 'Zeigt Details zum Würfelwurf im Chat direkt an.',
+            config: false,
+            type: new foundry.data.fields.BooleanField(),
+            scope: 'client',
+            default: false,
+            requiresReload: true,
+        },
+        {
             // Register last seen breaking changes version setting
             settingsName: IlarisGameSettingNames.lastSeenBreakingChangesVersion,
             name: 'Zuletzt gesehene Breaking Changes Version',

--- a/scripts/settings/configure-game-settings.model.js
+++ b/scripts/settings/configure-game-settings.model.js
@@ -19,6 +19,7 @@ export const IlarisGameSettingNames = {
     restrictEnergyCostSetting: 'restrictEnergyCostSetting',
     hideSyncKampfstileButton: 'hideSyncKampfstileButton',
     enableTabbingCharacterSheet: 'enableTabbingCharacterSheet',
+    showDiceRollInChat: 'showDiceRollInChat',
     hexTokenShapes: 'hexTokenShapes',
     defaultRangedDodgeTalent: 'defaultRangedDodgeTalent',
     lastSeenBreakingChangesVersion: 'lastSeenBreakingChangesVersion',

--- a/scripts/settings/ilaris-settings.dialog.js
+++ b/scripts/settings/ilaris-settings.dialog.js
@@ -113,6 +113,10 @@ export class IlarisSettingsDialog extends HandlebarsApplicationMixin(Application
                 ConfigureGameSettingsCategories.Ilaris,
                 IlarisGameSettingNames.enableTabbingCharacterSheet,
             ),
+            showDiceRollInChat: game.settings.get(
+                ConfigureGameSettingsCategories.Ilaris,
+                IlarisGameSettingNames.showDiceRollInChat,
+            ),
             hexTokenShapes: game.settings.get(
                 ConfigureGameSettingsCategories.Ilaris,
                 IlarisGameSettingNames.hexTokenShapes,
@@ -357,6 +361,12 @@ export class IlarisSettingsDialog extends HandlebarsApplicationMixin(Application
                 inputType: 'checkbox',
             },
             {
+                key: 'showDiceRollInChat',
+                name: IlarisGameSettingNames.showDiceRollInChat,
+                scope: 'client',
+                inputType: 'checkbox',
+            },
+            {
                 key: 'hexTokenShapes',
                 name: IlarisGameSettingNames.hexTokenShapes,
                 scope: 'world',
@@ -440,6 +450,11 @@ export class IlarisSettingsDialog extends HandlebarsApplicationMixin(Application
         await game.settings.set(
             ConfigureGameSettingsCategories.Ilaris,
             IlarisGameSettingNames.enableTabbingCharacterSheet,
+            false,
+        )
+        await game.settings.set(
+            ConfigureGameSettingsCategories.Ilaris,
+            IlarisGameSettingNames.showDiceRollInChat,
             false,
         )
 

--- a/scripts/settings/templates/ilaris-settings_general.hbs
+++ b/scripts/settings/templates/ilaris-settings_general.hbs
@@ -76,4 +76,12 @@
         </div>
         <input type="checkbox" name="general.enableTabbingCharacterSheet" {{#if settings.enableTabbingCharacterSheet}}checked{{/if}}>
     </div>
+    <div class="setting-row">
+        <div class="setting-label-block">
+            <span class="setting-label">Würfel details im Chat direkt anzeigen</span>
+            <span class="setting-scope"><i class="fas fa-user"></i> Lokal</span>
+            <p class="setting-hint">Zeigt Details zum Würfelwurf im Chat direkt an.</p>
+        </div>
+        <input type="checkbox" name="general.showDiceRollInChat" {{#if settings.showDiceRollInChat}}checked{{/if}}>
+    </div>
 </section>


### PR DESCRIPTION
Allow display of dice roll details directly with feature flag, per
default disabled, like previous behaviour.

Resolves https://github.com/Ilaris-Tools/IlarisFoundryVTT/issues/464