### PR TITLE
fix: hero name in charactersheet field doesn't grow or truncate

### DIFF
--- a/scripts/actors/styles/actor-sheet.css
+++ b/scripts/actors/styles/actor-sheet.css
@@ -29,6 +29,19 @@
   flex: auto;
   align-items: center;
   justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.ilaris.sheet.actor.helden .heroname {
+  flex: 1;
+}
+
+.ilaris.sheet.actor.helden .heroname input {
+  text-overflow: ellipsis;
+  
+  width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .ilaris.sheet.actor.helden .hw {

--- a/scripts/actors/templates/held/held-header.hbs
+++ b/scripts/actors/templates/held/held-header.hbs
@@ -1,8 +1,7 @@
 <section class="header" data-group="primary">
     <div class=heroheader>
-        <div>
-        <h1><input name="name" type="text" value="{{actor.name}}" /></h1>
-
+        <div class="heroname">
+            <h1><input name="name" type="text" value="{{actor.name}}" /></h1>
         </div>
         <div class="flexrow">
         {{#each (range 1 (add actor.system.schips.schips 1)) as |index|}}


### PR DESCRIPTION
## 📋 Standard PR Informationen

### Problem
Lange Heldennamen werden abgeschnitten obwohl im Dokument noch Platz verfügbar ist
> Realworld Beispiel einer meiner Spieler:
<img width="677" height="95" alt="Screenshot_20260722_093055" src="https://github.com/user-attachments/assets/845d2239-2cb4-4316-a4de-569f6ec5456b" />

---

### Fix
Beim Wrapper um den Input flex grow aktivieren und als kleines visuelles Extra text-ellipsis aktivieren für Namen die trotzdem zu lang sind.
<img width="677" height="95" alt="Screenshot_20260722_093030" src="https://github.com/user-attachments/assets/99dbdef1-8201-4b3c-9bf1-59ce1a3f498e" />
<img width="676" height="95" alt="Screenshot_20260722_093217" src="https://github.com/user-attachments/assets/c56ecd13-8332-4432-b42a-53d24bc1f329" />