### PR TITLE
fix: skill dialog roll fails with deprecated Foundry roll-mode API

### DIFF
--- a/scripts/combat/dialogs/angriff.js
+++ b/scripts/combat/dialogs/angriff.js
@@ -364,17 +364,12 @@ export class AngriffDialog extends CombatDialog {
                 rollResult.templatePath,
                 templateData,
             )
-            await rollResult.roll.toMessage(
-                {
-                    speaker: this.speaker,
-                    flavor: html_roll,
-                    blind: true,
-                    whisper: [game.user.id],
-                },
-                {
-                    messageMode: 'gmroll',
-                },
-            )
+            await rollResult.roll.toMessage({
+                speaker: this.speaker,
+                flavor: html_roll,
+                blind: true,
+                whisper: [game.user.id],
+            })
 
             // Store the defense roll result
             this.lastDefenseRoll = {

--- a/scripts/combat/dialogs/combat-dialog.js
+++ b/scripts/combat/dialogs/combat-dialog.js
@@ -700,17 +700,12 @@ export class CombatDialog extends HandlebarsApplicationMixin(ApplicationV2) {
                 rollResult.templatePath,
                 templateData,
             )
-            await rollResult.roll.toMessage(
-                {
-                    speaker: this.speaker,
-                    flavor: html_roll,
-                    blind: true,
-                    whisper: [game.user.id],
-                },
-                {
-                    messageMode: 'gmroll',
-                },
-            )
+            await rollResult.roll.toMessage({
+                speaker: this.speaker,
+                flavor: html_roll,
+                blind: true,
+                whisper: [game.user.id],
+            })
         } else {
             await postRollToChat(rollResult, this.speaker, this.rollmode)
         }

--- a/scripts/combat/dialogs/target-selection.js
+++ b/scripts/combat/dialogs/target-selection.js
@@ -211,8 +211,16 @@ export class TargetSelectionDialog extends HandlebarsApplicationMixin(Applicatio
         try {
             const targetTokenIds = selectedIds.map((target) => target.tokenId)
             game.user.updateTokenTargets(targetTokenIds)
+            game.user.targets.clear()
+            for (const target of selectedIds) {
+                const token = canvas.tokens.placeables.find((t) => t.id === target.tokenId)
+                if (token) {
+                    token.setTarget(true, { releaseOthers: false })
+                }
+            }
             console.log(
                 `Updated Foundry targets to match dialog selection: ${targetTokenIds.length} targets`,
+                `Updated Foundry targets to match dialog selection: ${game.user.targets.size} targets`,
             )
         } catch (error) {
             console.warn('Could not update Foundry token targets:', error)

--- a/scripts/skills/_spec/skills-api.spec.js
+++ b/scripts/skills/_spec/skills-api.spec.js
@@ -70,8 +70,8 @@ function setupSkillDialogGlobals() {
             xd20_choice: {},
             schips_choice: {},
         },
-        Dice: {
-            rollModes: {
+        ChatMessage: {
+            modes: {
                 roll: 'roll',
             },
         },
@@ -85,7 +85,7 @@ function setupSkillDialogGlobals() {
         settings: {
             get: jest.fn((namespace, key) => {
                 if (namespace === 'Ilaris' && key === 'realFumbleCrits') return false
-                if (namespace === 'core' && key === 'rollMode') return 'roll'
+                if (namespace === 'core' && key === 'messageMode') return 'roll'
                 return null
             }),
         },

--- a/scripts/skills/dialogs/fertigkeit.js
+++ b/scripts/skills/dialogs/fertigkeit.js
@@ -89,7 +89,7 @@ export class FertigkeitDialog extends HandlebarsApplicationMixin(ApplicationV2) 
             choices_schips: CONFIG.ILARIS.schips_choice,
             checked_schips: '0',
             hasSchips,
-            rollModes: CONFIG.Dice.rollModes,
+            rollModes: CONFIG.ChatMessage.modes,
             defaultRollMode: game.settings.get('core', 'messageMode'),
             dialogId: this.dialogId,
             summary: this.summary,
@@ -489,7 +489,7 @@ export class FertigkeitDialog extends HandlebarsApplicationMixin(ApplicationV2) 
         // Get roll mode
         const rollmode =
             html.querySelector(`#rollMode-${this.dialogId}`)?.value ||
-            game.settings.get('core', 'rollMode')
+            game.settings.get('core', 'messageMode')
 
         // Build formula
         const formula = `${modifierState.diceFormula} + ${modifierState.effectivePW} + ${modifierState.globalermod} + ${modifierState.hoheQualitaetMod} + ${modifierState.modifikator}`


### PR DESCRIPTION
Switch to CONFIG.ChatMessage.modes (matching CombatDialog) and the core.messageMode setting for the fallback default.

fixes #487