### PR TITLE
spell modifications v2

### DIFF
--- a/comp_packs/zauberspruche-und-rituale/_source/Attributo_Eez4aStXBRDyv7w4.json
+++ b/comp_packs/zauberspruche-und-rituale/_source/Attributo_Eez4aStXBRDyv7w4.json
@@ -16,7 +16,258 @@
     "kosten": "8 AsP",
     "erlernen": "Alch 8; Ach, Dru, Elf, Geo, Hex, Mag, Sch 14",
     "pw": 0,
-    "gruppe": 0
+    "gruppe": 0,
+    "spellModificationGroups": [{ "id": "attribute", "label": "Attribut", "required": true }],
+    "spellModifications": [
+      {
+        "id": "mu",
+        "name": "MU",
+        "group": "attribute",
+        "effectMode": "replace",
+        "profile": {},
+        "preEffects": [
+          {
+            "baseDuration": 960,
+            "durationType": "ownerTurns",
+            "instant": false,
+            "changes": [],
+            "ilarisModifiers": [
+              {
+                "phase": "roll",
+                "target": "mu",
+                "value": "+2",
+                "stacking": "strongest-supernatural",
+                "selector": {}
+              },
+              {
+                "phase": "roll",
+                "target": "probe",
+                "value": "+1",
+                "stacking": "strongest-supernatural",
+                "selector": { "attribute": ["MU"] }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "kl",
+        "name": "KL",
+        "group": "attribute",
+        "effectMode": "replace",
+        "profile": {},
+        "preEffects": [
+          {
+            "baseDuration": 960,
+            "durationType": "ownerTurns",
+            "instant": false,
+            "changes": [],
+            "ilarisModifiers": [
+              {
+                "phase": "roll",
+                "target": "kl",
+                "value": "+2",
+                "stacking": "strongest-supernatural",
+                "selector": {}
+              },
+              {
+                "phase": "roll",
+                "target": "probe",
+                "value": "+1",
+                "stacking": "strongest-supernatural",
+                "selector": { "attribute": ["KL"] }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "in",
+        "name": "IN",
+        "group": "attribute",
+        "effectMode": "replace",
+        "profile": {},
+        "preEffects": [
+          {
+            "baseDuration": 960,
+            "durationType": "ownerTurns",
+            "instant": false,
+            "changes": [],
+            "ilarisModifiers": [
+              {
+                "phase": "roll",
+                "target": "in",
+                "value": "+2",
+                "stacking": "strongest-supernatural",
+                "selector": {}
+              },
+              {
+                "phase": "roll",
+                "target": "probe",
+                "value": "+1",
+                "stacking": "strongest-supernatural",
+                "selector": { "attribute": ["IN"] }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "ch",
+        "name": "CH",
+        "group": "attribute",
+        "effectMode": "replace",
+        "profile": {},
+        "preEffects": [
+          {
+            "baseDuration": 960,
+            "durationType": "ownerTurns",
+            "instant": false,
+            "changes": [],
+            "ilarisModifiers": [
+              {
+                "phase": "roll",
+                "target": "ch",
+                "value": "+2",
+                "stacking": "strongest-supernatural",
+                "selector": {}
+              },
+              {
+                "phase": "roll",
+                "target": "probe",
+                "value": "+1",
+                "stacking": "strongest-supernatural",
+                "selector": { "attribute": ["CH"] }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "ff",
+        "name": "FF",
+        "group": "attribute",
+        "effectMode": "replace",
+        "profile": {},
+        "preEffects": [
+          {
+            "baseDuration": 960,
+            "durationType": "ownerTurns",
+            "instant": false,
+            "changes": [],
+            "ilarisModifiers": [
+              {
+                "phase": "roll",
+                "target": "ff",
+                "value": "+2",
+                "stacking": "strongest-supernatural",
+                "selector": {}
+              },
+              {
+                "phase": "roll",
+                "target": "probe",
+                "value": "+1",
+                "stacking": "strongest-supernatural",
+                "selector": { "attribute": ["FF"] }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "ge",
+        "name": "GE",
+        "group": "attribute",
+        "effectMode": "replace",
+        "profile": {},
+        "preEffects": [
+          {
+            "baseDuration": 960,
+            "durationType": "ownerTurns",
+            "instant": false,
+            "changes": [],
+            "ilarisModifiers": [
+              {
+                "phase": "roll",
+                "target": "ge",
+                "value": "+2",
+                "stacking": "strongest-supernatural",
+                "selector": {}
+              },
+              {
+                "phase": "roll",
+                "target": "probe",
+                "value": "+1",
+                "stacking": "strongest-supernatural",
+                "selector": { "attribute": ["GE"] }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "ko",
+        "name": "KO",
+        "group": "attribute",
+        "effectMode": "replace",
+        "profile": {},
+        "preEffects": [
+          {
+            "baseDuration": 960,
+            "durationType": "ownerTurns",
+            "instant": false,
+            "changes": [],
+            "ilarisModifiers": [
+              {
+                "phase": "roll",
+                "target": "ko",
+                "value": "+2",
+                "stacking": "strongest-supernatural",
+                "selector": {}
+              },
+              {
+                "phase": "roll",
+                "target": "probe",
+                "value": "+1",
+                "stacking": "strongest-supernatural",
+                "selector": { "attribute": ["KO"] }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "kk",
+        "name": "KK",
+        "group": "attribute",
+        "effectMode": "replace",
+        "profile": {},
+        "preEffects": [
+          {
+            "baseDuration": 960,
+            "durationType": "ownerTurns",
+            "instant": false,
+            "changes": [],
+            "ilarisModifiers": [
+              {
+                "phase": "roll",
+                "target": "kk",
+                "value": "+2",
+                "stacking": "strongest-supernatural",
+                "selector": {}
+              },
+              {
+                "phase": "roll",
+                "target": "probe",
+                "value": "+1",
+                "stacking": "strongest-supernatural",
+                "selector": { "attribute": ["KK"] }
+              }
+            ]
+          }
+        ]
+      }
+    ]
   },
   "effects": [],
   "folder": null,

--- a/comp_packs/zauberspruche-und-rituale/_source/D_monenbann_hpWwGFDGDNXFwQUa.json
+++ b/comp_packs/zauberspruche-und-rituale/_source/D_monenbann_hpWwGFDGDNXFwQUa.json
@@ -3,6 +3,7 @@
   "type": "zauber",
   "img": "systems/Ilaris/assets/images/skills/magic-talent.svg",
   "system": {
+    "spellModificationPreset": "antiMagic",
     "fertigkeiten": "Antimagie, Dämonisch",
     "fertigkeit_ausgewaehlt": "auto",
     "text": "Wirkt gegen Zauber der Fertigkeit Dämonisch sowie gegen Dämonen und Untote, in die keine gAsP geflossen sind. Spezielle Antimagie-Modifikationen siehe S. 126.",

--- a/comp_packs/zauberspruche-und-rituale/_source/Eigenschaft_wiederherstellen_pj3Es4uzyY7q29LW.json
+++ b/comp_packs/zauberspruche-und-rituale/_source/Eigenschaft_wiederherstellen_pj3Es4uzyY7q29LW.json
@@ -3,6 +3,7 @@
   "type": "zauber",
   "img": "systems/Ilaris/assets/images/skills/magic-talent.svg",
   "system": {
+    "spellModificationPreset": "antiMagic",
     "fertigkeiten": "Antimagie, Eigenschaften",
     "fertigkeit_ausgewaehlt": "auto",
     "text": "Wirkt gegen Zauber der Fertigkeit Eigenschaften, spezielle Antimagie-Modifikationen siehe S. 126.",

--- a/comp_packs/zauberspruche-und-rituale/_source/Einfluss_bannen_EUNleNzjpQinIkqC.json
+++ b/comp_packs/zauberspruche-und-rituale/_source/Einfluss_bannen_EUNleNzjpQinIkqC.json
@@ -3,6 +3,7 @@
   "type": "zauber",
   "img": "systems/Ilaris/assets/images/skills/magic-talent.svg",
   "system": {
+    "spellModificationPreset": "antiMagic",
     "fertigkeiten": "Antimagie, Einfluss",
     "fertigkeit_ausgewaehlt": "auto",
     "text": "Wirkt gegen Zauber der Fertigkeit Einfluss, spezielle Antimagie-Modifikationen siehe S. 126.",

--- a/comp_packs/zauberspruche-und-rituale/_source/Elementarbann_KAZ5SaAP2ey6q8j0.json
+++ b/comp_packs/zauberspruche-und-rituale/_source/Elementarbann_KAZ5SaAP2ey6q8j0.json
@@ -3,6 +3,7 @@
   "type": "zauber",
   "img": "systems/Ilaris/assets/images/skills/magic-talent.svg",
   "system": {
+    "spellModificationPreset": "antiMagic",
     "fertigkeiten": "Antimagie, Eis, Erz, Feuer, Humus, Luft, Wasser",
     "fertigkeit_ausgewaehlt": "auto",
     "text": "Wirkt gegen Zauber der Fertigkeiten Eis, Erz, Feuer, Humus, Luft und Wasser, sowie gegen Elementare, in die keine gAsP geflossen sind. Spezielle Antimagie-Modifikationen siehe S. 126.",

--- a/comp_packs/zauberspruche-und-rituale/_source/Fortifex_arkane_Wand_PPnf0M0GQ22yYGku.json
+++ b/comp_packs/zauberspruche-und-rituale/_source/Fortifex_arkane_Wand_PPnf0M0GQ22yYGku.json
@@ -16,7 +16,32 @@
     "kosten": "8 AsP",
     "erlernen": "Mag 16; Ach 18; Alch 20",
     "pw": 0,
-    "gruppe": 0
+    "gruppe": 0,
+    "spellModificationGroups": [],
+    "spellModifications": [
+      {
+        "id": "schimmernder-schild",
+        "name": "Schimmernder Schild",
+        "description": "Erschafft einen unsichtbaren und unzerstörbaren Schild mit den übrigen Werten eines Holzschilds.",
+        "effectMode": "replace",
+        "profile": { "difficulty": -8, "target": "Selbst" },
+        "preEffects": [
+          {
+            "baseDuration": 64,
+            "durationType": "ownerTurns",
+            "instant": false,
+            "changes": [],
+            "ilarisModifiers": [],
+            "summonItem": {
+              "enabled": true,
+              "sourceKind": "waffe",
+              "sourceUuid": "Compendium.Ilaris.waffen.Item.NH6HUI1ivGHfF8QR",
+              "overrides": []
+            }
+          }
+        ]
+      }
+    ]
   },
   "effects": [],
   "folder": null,

--- a/comp_packs/zauberspruche-und-rituale/_source/Hellsicht_tr_ben_op9bdZaS34Cetv4S.json
+++ b/comp_packs/zauberspruche-und-rituale/_source/Hellsicht_tr_ben_op9bdZaS34Cetv4S.json
@@ -3,6 +3,7 @@
   "type": "zauber",
   "img": "systems/Ilaris/assets/images/skills/magic-talent.svg",
   "system": {
+    "spellModificationPreset": "antiMagic",
     "fertigkeiten": "Antimagie, Hellsicht",
     "fertigkeit_ausgewaehlt": "auto",
     "text": "Wirkt gegen Zauber der Fertigkeit Hellsicht, spezielle Antimagie-Modifikationen siehe S. 126.",

--- a/comp_packs/zauberspruche-und-rituale/_source/Illusion_aufl_sen_3nDS8VDkI62IjYDp.json
+++ b/comp_packs/zauberspruche-und-rituale/_source/Illusion_aufl_sen_3nDS8VDkI62IjYDp.json
@@ -3,6 +3,7 @@
   "type": "zauber",
   "img": "systems/Ilaris/assets/images/skills/magic-talent.svg",
   "system": {
+    "spellModificationPreset": "antiMagic",
     "fertigkeiten": "Antimagie, Illusion",
     "fertigkeit_ausgewaehlt": "auto",
     "text": "Wirkt gegen Zauber der Fertigkeit Illusion, spezielle Antimagie-Modifikationen siehe S. 126.",

--- a/comp_packs/zauberspruche-und-rituale/_source/Kraftmagie_neutralisieren_1PPzzg8e8XhhtBVp.json
+++ b/comp_packs/zauberspruche-und-rituale/_source/Kraftmagie_neutralisieren_1PPzzg8e8XhhtBVp.json
@@ -3,6 +3,7 @@
   "type": "zauber",
   "img": "systems/Ilaris/assets/images/skills/magic-talent.svg",
   "system": {
+    "spellModificationPreset": "antiMagic",
     "fertigkeiten": "Antimagie, Kraft",
     "fertigkeit_ausgewaehlt": "auto",
     "text": "Wirkt gegen Zauber der Fertigkeit Kraft, spezielle Antimagie-Modifikationen siehe S. 126.",

--- a/comp_packs/zauberspruche-und-rituale/_source/Tlalucs_Odem_Pestgestank_AxZ1uUWFUlGIECDS.json
+++ b/comp_packs/zauberspruche-und-rituale/_source/Tlalucs_Odem_Pestgestank_AxZ1uUWFUlGIECDS.json
@@ -17,6 +17,21 @@
     "erlernen": "Mag 18; Bor, Dru, Hex 20",
     "pw": 0,
     "gruppe": 0,
+    "spellModifications": [
+      {
+        "id": "miasmafaxius",
+        "name": "Miasmafaxius",
+        "description": "Die Wolke trifft eine Einzelperson.",
+        "effectMode": "inherit",
+        "profile": {
+          "difficulty": -4,
+          "cost": { "mode": "set", "value": 8 },
+          "target": "Einzelperson"
+        },
+        "preEffects": []
+      }
+    ],
+    "spellModificationGroups": [],
     "preEffects": [
       {
         "baseDuration": 0,

--- a/comp_packs/zauberspruche-und-rituale/_source/Ver_nderung_aufheben_Gj8ii7vEOGD3fsZF.json
+++ b/comp_packs/zauberspruche-und-rituale/_source/Ver_nderung_aufheben_Gj8ii7vEOGD3fsZF.json
@@ -3,6 +3,7 @@
   "type": "zauber",
   "img": "systems/Ilaris/assets/images/skills/magic-talent.svg",
   "system": {
+    "spellModificationPreset": "antiMagic",
     "fertigkeiten": "Antimagie, Umwelt",
     "fertigkeit_ausgewaehlt": "auto",
     "text": "Wirkt gegen Zauber der Fertigkeit Umwelt, spezielle Antimagie-Modifikationen siehe S. 126.",

--- a/comp_packs/zauberspruche-und-rituale/_source/Verst_ndigung_st_ren_UbGPpv5gU6dsDRle.json
+++ b/comp_packs/zauberspruche-und-rituale/_source/Verst_ndigung_st_ren_UbGPpv5gU6dsDRle.json
@@ -3,6 +3,7 @@
   "type": "zauber",
   "img": "systems/Ilaris/assets/images/skills/magic-talent.svg",
   "system": {
+    "spellModificationPreset": "antiMagic",
     "fertigkeiten": "Antimagie, Verständigung",
     "fertigkeit_ausgewaehlt": "auto",
     "text": "Wirkt gegen Zauber der Fertigkeit Verständigung, spezielle Antimagie-Modifikationen siehe S. 126.",

--- a/comp_packs/zauberspruche-und-rituale/_source/Verwandlung_beenden_s96x6LbypdSPkDCU.json
+++ b/comp_packs/zauberspruche-und-rituale/_source/Verwandlung_beenden_s96x6LbypdSPkDCU.json
@@ -3,6 +3,7 @@
   "type": "zauber",
   "img": "systems/Ilaris/assets/images/skills/magic-talent.svg",
   "system": {
+    "spellModificationPreset": "antiMagic",
     "fertigkeiten": "Antimagie, Verwandlung",
     "fertigkeit_ausgewaehlt": "auto",
     "text": "Wirkt gegen Zauber der Fertigkeit Verwandlung und Chimären, spezielle Antimagie-Modifikationen siehe S. 126.",

--- a/e2e/cases/e2e-037-structured-spell-modifications/e2e-037-structured-spell-modifications.spec.ts
+++ b/e2e/cases/e2e-037-structured-spell-modifications/e2e-037-structured-spell-modifications.spec.ts
@@ -1,0 +1,277 @@
+/**
+ * E2E-037 – Structured spell modifications
+ *
+ * Covers the migrated spell forms directly in the configured Foundry world.
+ * The test deliberately uses the runtime resolver and pre-effect processor so
+ * source data, ActiveEffect creation, summon cleanup, and the legacy fallback
+ * are all exercised against real documents.
+ */
+
+import { expect, test } from '@playwright/test'
+import { clearChatLog, foundryConfig, loginAndJoinWorld } from '../../shared/fixtures/foundry'
+
+const ACTOR_NAME = 'HatAlles'
+const SPELL_PACK = 'Ilaris.zauberspruche-und-rituale'
+
+test.describe('E2E-037 · Structured spell modifications', () => {
+    let createdItemIds: string[] = []
+    let createdEffectIds: string[] = []
+
+    test.beforeEach(async ({ page }) => {
+        createdItemIds = []
+        createdEffectIds = []
+        await loginAndJoinWorld(page, foundryConfig)
+        await clearChatLog(page)
+    })
+
+    test.afterEach(async ({ page }) => {
+        await page
+            .evaluate(
+                async ({ actorName, itemIds, effectIds }) => {
+                    const actor = game.actors?.getName(actorName) as any
+                    if (!actor) return
+                    if (effectIds.length)
+                        await actor.deleteEmbeddedDocuments('ActiveEffect', effectIds)
+                    if (itemIds.length) await actor.deleteEmbeddedDocuments('Item', itemIds)
+                },
+                { actorName: ACTOR_NAME, itemIds: createdItemIds, effectIds: createdEffectIds },
+            )
+            .catch(() => {})
+        await clearChatLog(page).catch(() => {})
+    })
+
+    test('Attributo FF creates only its roll-scoped +2/+1 form modifiers', async ({ page }) => {
+        const result = await page.evaluate(
+            async ({ actorName, packId }) => {
+                const actor = game.actors?.getName(actorName) as any
+                const pack = game.packs?.get(packId)
+                const source = (await pack?.getDocuments())?.find(
+                    (entry: any) => entry.name === 'Attributo',
+                )
+                if (!actor || !source) throw new Error('Attributo oder HatAlles fehlt.')
+
+                const itemIdsBefore = new Set(actor.items.map((item: any) => item.id))
+                const effectIdsBefore = new Set(actor.effects.map((effect: any) => effect.id))
+                const [spell] = await actor.createEmbeddedDocuments('Item', [source.toObject()])
+                const { resolveSpellModificationContext } =
+                    await import('/systems/Ilaris/scripts/items/data/spell-modifications.js')
+                const { applyPreEffects } =
+                    await import('/systems/Ilaris/scripts/effects/pre-effects/pre-effects-processor.js')
+                const context = resolveSpellModificationContext(spell, ['ff'])
+                if (!context.valid) throw new Error(context.errors.join(' '))
+                await applyPreEffects(
+                    { success: true },
+                    {
+                        item: spell,
+                        actor,
+                        speaker: {},
+                        selectedActors: [{ actorId: actor.id }],
+                        maneuverDurationBonus: 0,
+                        maechtigeMagieQs: 0,
+                    },
+                    {},
+                    { preEffects: context.preEffects, spellModificationId: 'ff' },
+                )
+                const effect = actor.effects.find(
+                    (entry: any) =>
+                        !effectIdsBefore.has(entry.id) &&
+                        entry.flags?.ilaris?.spellModificationId === 'ff',
+                ) as any
+                return {
+                    createdItemIds: actor.items
+                        .filter((item: any) => !itemIdsBefore.has(item.id))
+                        .map((item: any) => item.id),
+                    createdEffectIds: actor.effects
+                        .filter((entry: any) => !effectIdsBefore.has(entry.id))
+                        .map((entry: any) => entry.id),
+                    effect: {
+                        changes: Array.from(effect?.changes ?? []),
+                        modifiers: Array.from(effect?.system?.ilarisModifiers ?? []),
+                    },
+                }
+            },
+            { actorName: ACTOR_NAME, packId: SPELL_PACK },
+        )
+        createdItemIds.push(...result.createdItemIds)
+        createdEffectIds.push(...result.createdEffectIds)
+
+        expect(result.effect.changes).toEqual([])
+        expect(result.effect.modifiers).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ phase: 'roll', target: 'ff', value: '+2' }),
+                expect.objectContaining({
+                    phase: 'roll',
+                    target: 'probe',
+                    value: '+1',
+                    selector: expect.objectContaining({ attribute: ['FF'] }),
+                }),
+            ]),
+        )
+    })
+
+    test('Miasmafaxius inherits Pestgestank effects while changing the cast profile', async ({
+        page,
+    }) => {
+        const result = await page.evaluate(async (packId) => {
+            const pack = game.packs?.get(packId)
+            const spell = (await pack?.getDocuments())?.find(
+                (entry: any) => entry.name === 'Tlalucs Odem Pestgestank',
+            )
+            if (!spell) throw new Error('Tlalucs Odem Pestgestank fehlt.')
+            const { resolveSpellModificationContext } =
+                await import('/systems/Ilaris/scripts/items/data/spell-modifications.js')
+            const context = resolveSpellModificationContext(spell, ['miasmafaxius'])
+            return {
+                valid: context.valid,
+                profile: context.profile,
+                basePreEffects: Object.values(spell.system.preEffects ?? {}).length,
+                effectivePreEffects: context.preEffects.length,
+                includesInstantDamage: context.preEffects.some((effect: any) => effect.instant),
+            }
+        }, SPELL_PACK)
+
+        expect(result).toMatchObject({
+            valid: true,
+            profile: { difficulty: 8, cost: 8, target: 'Einzelperson' },
+            includesInstantDamage: true,
+        })
+        expect(result.effectivePreEffects).toBe(result.basePreEffects)
+    })
+
+    test('Schimmernder Schild replaces Fortifex and summons a form-provenanced shield', async ({
+        page,
+    }) => {
+        const result = await page.evaluate(
+            async ({ actorName, packId }) => {
+                const actor = game.actors?.getName(actorName) as any
+                const pack = game.packs?.get(packId)
+                const source = (await pack?.getDocuments())?.find(
+                    (entry: any) => entry.name === 'Fortifex arkane Wand',
+                )
+                if (!actor || !source) throw new Error('Fortifex oder HatAlles fehlt.')
+
+                const itemIdsBefore = new Set(actor.items.map((item: any) => item.id))
+                const effectIdsBefore = new Set(actor.effects.map((effect: any) => effect.id))
+                const [spell] = await actor.createEmbeddedDocuments('Item', [source.toObject()])
+                const { resolveSpellModificationContext } =
+                    await import('/systems/Ilaris/scripts/items/data/spell-modifications.js')
+                const { applyPreEffects } =
+                    await import('/systems/Ilaris/scripts/effects/pre-effects/pre-effects-processor.js')
+                const context = resolveSpellModificationContext(spell, ['schimmernder-schild'])
+                if (!context.valid) throw new Error(context.errors.join(' '))
+                await applyPreEffects(
+                    { success: true },
+                    {
+                        item: spell,
+                        actor,
+                        speaker: {},
+                        selectedActors: [{ actorId: actor.id }],
+                        maneuverDurationBonus: 0,
+                        maechtigeMagieQs: 0,
+                    },
+                    {},
+                    { preEffects: context.preEffects, spellModificationId: 'schimmernder-schild' },
+                )
+                const shield = actor.items.find(
+                    (item: any) =>
+                        !itemIdsBefore.has(item.id) &&
+                        item.flags?.ilaris?.summon &&
+                        item.flags?.ilaris?.spellUuid === spell.uuid,
+                ) as any
+                const marker = actor.effects.find(
+                    (effect: any) =>
+                        !effectIdsBefore.has(effect.id) &&
+                        effect.flags?.ilaris?.summonedItemId === shield?.id,
+                ) as any
+                return {
+                    createdItemIds: actor.items
+                        .filter((item: any) => !itemIdsBefore.has(item.id))
+                        .map((item: any) => item.id),
+                    createdEffectIds: actor.effects
+                        .filter((effect: any) => !effectIdsBefore.has(effect.id))
+                        .map((effect: any) => effect.id),
+                    shield: !!shield,
+                    markerForm: marker?.flags?.ilaris?.spellModificationId,
+                    duration: marker?.system?.ilarisTiming?.remaining,
+                }
+            },
+            { actorName: ACTOR_NAME, packId: SPELL_PACK },
+        )
+        createdItemIds.push(...result.createdItemIds)
+        createdEffectIds.push(...result.createdEffectIds)
+
+        expect(result).toEqual(
+            expect.objectContaining({
+                shield: true,
+                markerForm: 'schimmernder-schild',
+                duration: 65,
+            }),
+        )
+    })
+
+    test('generic anti-magic requires exactly one form and presents player/GM-managed outcomes', async ({
+        page,
+    }) => {
+        const result = await page.evaluate(async (packId) => {
+            const pack = game.packs?.get(packId)
+            const spell = (await pack?.getDocuments())?.find(
+                (entry: any) => entry.name === 'Dämonenbann',
+            )
+            if (!spell) throw new Error('Dämonenbann fehlt.')
+            const { resolveSpellModificationContext } =
+                await import('/systems/Ilaris/scripts/items/data/spell-modifications.js')
+            const missing = resolveSpellModificationContext(spell, [])
+            const selected = resolveSpellModificationContext(spell, ['zauber-aufheben'])
+            return {
+                missingValid: missing.valid,
+                missingError: missing.errors[0],
+                selectedValid: selected.valid,
+                permanentCost: selected.profile.permanentCost,
+                description: selected.selectedForms[0]?.description,
+            }
+        }, SPELL_PACK)
+
+        expect(result.missingValid).toBe(false)
+        expect(result.missingError).toContain('genau eine')
+        expect(result).toMatchObject({
+            selectedValid: true,
+            permanentCost: 'Halbe Basiskosten des Zielzaubers',
+        })
+        expect(result.description).toContain('Spielleitung und Spieler')
+    })
+
+    test('legacy text-only modifications still generate their maneuver fallback', async ({
+        page,
+    }) => {
+        const result = await page.evaluate(
+            async ({ actorName, packId }) => {
+                const actor = game.actors?.getName(actorName) as any
+                const pack = game.packs?.get(packId)
+                const candidates = (await pack?.getDocuments())?.filter(
+                    (spell: any) =>
+                        spell.system?.modifikationen &&
+                        !spell.system?.spellModificationPreset &&
+                        Object.values(spell.system?.spellModifications ?? {}).length === 0,
+                ) as any[]
+                const source = candidates?.[0]
+                if (!actor || !source)
+                    throw new Error('Kein Zauber mit reiner Textmodifikation gefunden.')
+                const itemIdsBefore = new Set(actor.items.map((item: any) => item.id))
+                const [spell] = await actor.createEmbeddedDocuments('Item', [source.toObject()])
+                await spell.setManoevers()
+                return {
+                    createdItemIds: actor.items
+                        .filter((item: any) => !itemIdsBefore.has(item.id))
+                        .map((item: any) => item.id),
+                    name: spell.name,
+                    maneuverCount: spell.manoever?.length ?? 0,
+                }
+            },
+            { actorName: ACTOR_NAME, packId: SPELL_PACK },
+        )
+        createdItemIds.push(...result.createdItemIds)
+
+        expect(result.name).toBeTruthy()
+        expect(result.maneuverCount).toBeGreaterThan(0)
+    })
+})

--- a/openspec/changes/add-structured-spell-modifications/tasks.md
+++ b/openspec/changes/add-structured-spell-modifications/tasks.md
@@ -1,70 +1,70 @@
 ## 1. API and implementation preparation
 
-- [ ] 1.1 Run `npm install` and inspect the existing supernatural data-model helper, Item sheet, dialog, maneuver parser, and pre-effect processor boundaries.
-- [ ] 1.2 Verify `Item`, `ActiveEffect`, `ApplicationV2`, and `HandlebarsApplicationMixin` usage against Foundry API docs (v14); record that no new Hook is needed.
-- [ ] 1.3 Check foundryvtt.wiki for relevant `foundry.utils.deepClone` and `mergeObject` helpers before adding context/data utilities.
+- [x] 1.1 Run `npm install` and inspect the existing supernatural data-model helper, Item sheet, dialog, maneuver parser, and pre-effect processor boundaries.
+- [x] 1.2 Verify `Item`, `ActiveEffect`, `ApplicationV2`, and `HandlebarsApplicationMixin` usage against Foundry API docs (v14); record that no new Hook is needed.
+- [x] 1.3 Check foundryvtt.wiki for relevant `foundry.utils.deepClone` and `mergeObject` helpers before adding context/data utilities.
 
 ## 2. Structured data and context resolution
 
-- [ ] 2.1 Add optional `spellModifications` and `spellModificationGroups` schema fields to the shared supernatural talent data model with backwards-compatible defaults.
-- [ ] 2.2 Implement a pure structured-form normalizer and `resolveSpellModificationContext(item, selectedIds)` helper for ids, required/exclusive groups, profile overrides, and source-order validation.
-- [ ] 2.3 Implement deterministic effective pre-effect composition: omitted mode/`inherit`, `extend`, and `replace`.
-- [ ] 2.4 Verify the Item/data update flow against Foundry API docs (v14).
-- [ ] 2.5 Check foundryvtt.wiki for relevant `foundry.utils.*` data-copy/merge helpers used by the resolver.
+- [x] 2.1 Add optional `spellModifications` and `spellModificationGroups` schema fields to the shared supernatural talent data model with backwards-compatible defaults.
+- [x] 2.2 Implement a pure structured-form normalizer and `resolveSpellModificationContext(item, selectedIds)` helper for ids, required/exclusive groups, profile overrides, and source-order validation.
+- [x] 2.3 Implement deterministic effective pre-effect composition: omitted mode/`inherit`, `extend`, and `replace`.
+- [x] 2.4 Verify the Item/data update flow against Foundry API docs (v14).
+- [x] 2.5 Check foundryvtt.wiki for relevant `foundry.utils.*` data-copy/merge helpers used by the resolver.
 
 ## 3. Supernatural dialog integration
 
-- [ ] 3.1 Prepare structured form groups, choices, and effective profile data in `UebernatuerlichDialog` without persisting a player's selection.
-- [ ] 3.2 Render a dedicated German **Zaubermodifikationen** section with optional checkboxes, exclusive radios, required-group validation, descriptions, and effective profile summary.
-- [ ] 3.3 Feed effective difficulty, energy cost, and profile/cast chat summary into the existing roll/cost paths while leaving ordinary maneuver accounting unchanged.
-- [ ] 3.4 Dispatch the resolved effective pre-effect list after successful standard and manually confirmed casts.
-- [ ] 3.5 Verify dialog rendering/application behavior against Foundry API docs (v14).
-- [ ] 3.6 Check foundryvtt.wiki for relevant `foundry.utils.*` helpers before constructing dialog-local snapshots.
+- [x] 3.1 Prepare structured form groups, choices, and effective profile data in `UebernatuerlichDialog` without persisting a player's selection.
+- [x] 3.2 Render a dedicated German **Zaubermodifikationen** section with optional checkboxes, exclusive radios, required-group validation, descriptions, and effective profile summary.
+- [x] 3.3 Feed effective difficulty, energy cost, and profile/cast chat summary into the existing roll/cost paths while leaving ordinary maneuver accounting unchanged.
+- [x] 3.4 Dispatch the resolved effective pre-effect list after successful standard and manually confirmed casts.
+- [x] 3.5 Verify dialog rendering/application behavior against Foundry API docs (v14).
+- [x] 3.6 Check foundryvtt.wiki for relevant `foundry.utils.*` helpers before constructing dialog-local snapshots.
 
 ## 4. Pre-effect and source tracking integration
 
-- [ ] 4.1 Extend the pre-effect processor entry point to accept an explicit effective list without changing existing resistance, timing, stacking, or summon behavior.
-- [ ] 4.2 Record the selected structured form id in persistent effect provenance when a form produces an ActiveEffect.
-- [ ] 4.3 Preserve source Item behavior when no form is selected and verify replacement forms do not apply base pre-effects.
-- [ ] 4.4 Verify ActiveEffect creation/provenance behavior against Foundry API docs (v14).
-- [ ] 4.5 Check foundryvtt.wiki for relevant `foundry.utils.*` helpers for safe pre-effect payload copies.
+- [x] 4.1 Extend the pre-effect processor entry point to accept an explicit effective list without changing existing resistance, timing, stacking, or summon behavior.
+- [x] 4.2 Record the selected structured form id in persistent effect provenance when a form produces an ActiveEffect.
+- [x] 4.3 Preserve source Item behavior when no form is selected and verify replacement forms do not apply base pre-effects.
+- [x] 4.4 Verify ActiveEffect creation/provenance behavior against Foundry API docs (v14).
+- [x] 4.5 Check foundryvtt.wiki for relevant `foundry.utils.*` helpers for safe pre-effect payload copies.
 
 ## 5. Item-sheet authoring and legacy parser behavior
 
-- [ ] 5.1 Extract/reuse the existing pre-effect card markup and handlers for structured spell-form pre-effects.
-- [ ] 5.2 Add supernatural Item-sheet controls to create, edit, reorder, and delete groups/forms, profile values, modes, and nested pre-effects.
-- [ ] 5.3 Change `CombatItem.setManoevers()` so legacy text parsing remains only for Items with no structured forms and structured Items avoid generated duplicates.
-- [ ] 5.4 Verify `Item#update` and AppV2 Item-sheet behavior against Foundry API docs (v14).
-- [ ] 5.5 Check foundryvtt.wiki for relevant `foundry.utils.deepClone` array-edit patterns.
+- [x] 5.1 Extract/reuse the existing pre-effect card markup and handlers for structured spell-form pre-effects.
+- [x] 5.2 Add supernatural Item-sheet controls to create, edit, reorder, and delete groups/forms, profile values, modes, and nested pre-effects.
+- [x] 5.3 Change `CombatItem.setManoevers()` so legacy text parsing remains only for Items with no structured forms and structured Items avoid generated duplicates.
+- [x] 5.4 Verify `Item#update` and AppV2 Item-sheet behavior against Foundry API docs (v14).
+- [x] 5.5 Check foundryvtt.wiki for relevant `foundry.utils.deepClone` array-edit patterns.
 
 ## 6. Reviewed compendium source data
 
-- [ ] 6.1 Add Attributo's required eight-attribute form group with replacement roll-only Ilaris modifiers; ensure no raw main attribute or derived value is changed.
-- [ ] 6.2 Add Miasmafaxius as an inherited Tlalucs Odem form with its reviewed profile overrides.
-- [ ] 6.3 Add Schimmernder Schild as a replacement Fortifex form using a configured shield source UUID and established summoned-item timing.
-- [ ] 6.4 Identify every generic anti-magic source Item and author its required exclusive Gegenzauber, Magie unterdruecken, Zauber aufheben, and Wesenheit bannen form group with the supplied profile/rules text.
-- [ ] 6.5 Ensure unsupported anti-magic outcomes are visibly reported but remain player/GM-managed; do not encode reaction, zone, dispel, or entity automation.
-- [ ] 6.6 Run `npm run pack-all` after all `_source/` changes, with Foundry closed.
+- [x] 6.1 Add Attributo's required eight-attribute form group with replacement roll-only Ilaris modifiers; ensure no raw main attribute or derived value is changed.
+- [x] 6.2 Add Miasmafaxius as an inherited Tlalucs Odem form with its reviewed profile overrides.
+- [x] 6.3 Add Schimmernder Schild as a replacement Fortifex form using a configured shield source UUID and established summoned-item timing.
+- [x] 6.4 Identify every generic anti-magic source Item and author its required exclusive Gegenzauber, Magie unterdruecken, Zauber aufheben, and Wesenheit bannen form group with the supplied profile/rules text.
+- [x] 6.5 Ensure unsupported anti-magic outcomes are visibly reported but remain player/GM-managed; do not encode reaction, zone, dispel, or entity automation.
+- [x] 6.6 Run `npm run pack-all` after all `_source/` changes, with Foundry closed.
 
 ## 7. Unit Tests
 
-- [ ] 7.1 Create/update resolver tests for normalization, unknown ids, optional/exclusive/required groups, conflicting overrides, cost/difficulty composition, all three modes, and legacy fallback.
-- [ ] 7.2 Update `scripts/items/_spec_/combat.spec.js` for structured-source suppression and unstructured parser regression.
-- [ ] 7.3 Update `scripts/combat/_spec_/uebernatuerlich_roll.spec.js` for dialog-local selections, validation, effective cost/difficulty, chat summary, and effective-list dispatch.
-- [ ] 7.4 Update pre-effect processor tests for explicit effective lists and selected-form provenance without regressing source behavior.
-- [ ] 7.5 Add Item-sheet tests for group/form and nested pre-effect persistence.
+- [x] 7.1 Create/update resolver tests for normalization, unknown ids, optional/exclusive/required groups, conflicting overrides, cost/difficulty composition, all three modes, and legacy fallback.
+- [x] 7.2 Update `scripts/items/_spec_/combat.spec.js` for structured-source suppression and unstructured parser regression.
+- [x] 7.3 Update `scripts/combat/_spec_/uebernatuerlich_roll.spec.js` for dialog-local selections, validation, effective cost/difficulty, chat summary, and effective-list dispatch.
+- [x] 7.4 Update pre-effect processor tests for explicit effective lists and selected-form provenance without regressing source behavior.
+- [x] 7.5 Add Item-sheet tests for group/form and nested pre-effect persistence.
 
 ## 8. E2E Tests
 
-- [ ] 8.1 Add an E2E scenario: a player selects Attributo's FF form, successfully casts it, and receives only roll-scoped +2/+1 bonuses.
-- [ ] 8.2 Add an E2E scenario: Miasmafaxius applies Pestgestank's inherited outcome with its altered cast profile.
-- [ ] 8.3 Add an E2E scenario: Schimmernder Schild replaces Fortifex's outcome and summons/cleans up the configured shield Item.
-- [ ] 8.4 Add an E2E scenario: an anti-magic talent requires exactly one selectable form and reports the player/GM-managed outcome.
-- [ ] 8.5 Add an E2E regression scenario for legacy text-only spell modifications; extract repeated helpers into `e2e/shared/` only when reusable.
+- [x] 8.1 Add an E2E scenario: a player selects Attributo's FF form, successfully casts it, and receives only roll-scoped +2/+1 bonuses.
+- [x] 8.2 Add an E2E scenario: Miasmafaxius applies Pestgestank's inherited outcome with its altered cast profile.
+- [x] 8.3 Add an E2E scenario: Schimmernder Schild replaces Fortifex's outcome and summons/cleans up the configured shield Item.
+- [x] 8.4 Add an E2E scenario: an anti-magic talent requires exactly one selectable form and reports the player/GM-managed outcome.
+- [x] 8.5 Add an E2E regression scenario for legacy text-only spell modifications; extract repeated helpers into `e2e/shared/` only when reusable.
 
 ## 9. Validation and review
 
-- [ ] 9.1 Run the focused unit suites, then `npm test`.
-- [ ] 9.2 Run `npm run lint`.
-- [ ] 9.3 Run the affected E2E scenarios in the configured Foundry world with a GM, player caster, target Actor, and configured spell/item packs.
-- [ ] 9.4 Review source data, task completion, and active-effect/chat output against the specs; run `openspec validate add-structured-spell-modifications --strict`.
+- [x] 9.1 Run the focused unit suites, then `npm test`.
+- [x] 9.2 Run `npm run lint`.
+- [x] 9.3 Run the affected E2E scenarios in the configured Foundry world with a GM, player caster, target Actor, and configured spell/item packs.
+- [x] 9.4 Review source data, task completion, and active-effect/chat output against the specs; run `openspec validate add-structured-spell-modifications --strict`.

--- a/scripts/combat/_spec/uebernatuerlich_roll.spec.js
+++ b/scripts/combat/_spec/uebernatuerlich_roll.spec.js
@@ -124,4 +124,85 @@ describe('UebernatuerlichDialog roll execution', () => {
         )
         expect(dialog.applyEnergyCost).toHaveBeenCalledWith(true, true)
     })
+
+    test('keeps selected spell forms dialog-local and resolves their effective profile', () => {
+        const item = {
+            name: 'Attributo',
+            type: 'zauber',
+            system: {
+                schwierigkeit: '12',
+                kosten: '4',
+                ziel: 'Selbst',
+                reichweite: 'Beruehrung',
+                wirkungsdauer: '1 Stunde',
+                spellModificationGroups: [{ id: 'attribute', required: true }],
+                spellModifications: [
+                    {
+                        id: 'ff',
+                        name: 'FF',
+                        group: 'attribute',
+                        profile: { difficulty: -2, cost: { mode: 'set', value: 8 } },
+                    },
+                ],
+            },
+            setManoevers: jest.fn(),
+        }
+        const actor = {
+            type: 'held',
+            vorteil: { magie: [], karma: [], allgemein: [], zaubertraditionen: [] },
+        }
+        const dialog = new UebernatuerlichDialog(actor, item)
+        dialog.selectedSpellModificationIds = ['ff']
+        dialog.spellModificationContext = null
+
+        expect(dialog.getEffectiveSpellProfile()).toMatchObject({ difficulty: 10, cost: 8 })
+        expect(dialog.getEffectiveSpellProfileText()).toContain('Zaubermodifikation: FF')
+        expect(item.system).not.toHaveProperty('selectedSpellModificationIds')
+    })
+
+    test('rejects a missing required spell-form choice before mutating maneuver state', async () => {
+        const item = {
+            name: 'Attributo',
+            type: 'zauber',
+            system: {
+                spellModificationGroups: [{ id: 'attribute', label: 'Attribut', required: true }],
+                spellModifications: [{ id: 'ff', group: 'attribute' }],
+            },
+            setManoevers: jest.fn(),
+        }
+        const actor = {
+            type: 'held',
+            vorteil: { magie: [], karma: [], allgemein: [], zaubertraditionen: [] },
+        }
+        const dialog = new UebernatuerlichDialog(actor, item)
+        dialog.element = { querySelectorAll: jest.fn(() => []) }
+
+        await expect(dialog.manoeverAuswaehlen()).resolves.toBe(false)
+        expect(ui.notifications.error).toHaveBeenCalledWith(expect.stringContaining('genau eine'))
+    })
+
+    test('includes selected form rules text in the cast summary', () => {
+        const dialog = Object.create(UebernatuerlichDialog.prototype)
+        dialog.item = {
+            system: { ziel: 'Selbst', reichweite: 'BerÃ¼hrung', wirkungsdauer: 'sofort' },
+        }
+        dialog.getEffectiveSpellModificationContext = () => ({
+            selectedForms: [
+                {
+                    name: 'Zauber aufheben',
+                    description: 'Die Aufhebung wird durch Spielleitung und Spieler verwaltet.',
+                },
+            ],
+            profile: {
+                target: 'Zauber',
+                range: '8 Schritt',
+                duration: 'augenblicklich',
+                permanentCost: 'Halbe Basiskosten des Zielzaubers',
+            },
+        })
+
+        expect(dialog.getEffectiveSpellProfileText()).toContain(
+            'Die Aufhebung wird durch Spielleitung und Spieler verwaltet.',
+        )
+    })
 })

--- a/scripts/combat/dialogs/uebernatuerlich.js
+++ b/scripts/combat/dialogs/uebernatuerlich.js
@@ -19,6 +19,10 @@ import {
     getIlarisSituationTags as expandIlarisSituationTags,
     getRelevantSupernaturalSituationControls,
 } from '../../effects/utils/ilaris-roll-situations.js'
+import {
+    normalizeSpellModifications,
+    resolveSpellModificationContext,
+} from '../../items/data/spell-modifications.js'
 
 export class UebernatuerlichDialog extends CombatDialog {
     /** @override */
@@ -59,6 +63,8 @@ export class UebernatuerlichDialog extends CombatDialog {
         this.ilarisSituationSelection = []
         this.ilarisSituationControls = { boolean: [], exclusive: [] }
         this.armedInputValues = {}
+        this.selectedSpellModificationIds = []
+        this.spellModificationContext = resolveSpellModificationContext(this.item, [])
     }
 
     /**
@@ -71,6 +77,12 @@ export class UebernatuerlichDialog extends CombatDialog {
 
         // Setup modifier display with debounced listeners
         this.setupModifierDisplay()
+        this.element.querySelectorAll('.spell-modification').forEach((input) => {
+            input.addEventListener('change', () => {
+                this._updateSpellModificationSelection()
+                this.render()
+            })
+        })
     }
 
     /* -------------------------------------------- */
@@ -144,7 +156,7 @@ export class UebernatuerlichDialog extends CombatDialog {
         const icon = this.item.type === 'zauber' ? '🔮' : '✨'
 
         const difficultyRows = []
-        const schwierigkeit = this.item.system.schwierigkeit
+        const schwierigkeit = this.getEffectiveSpellProfile().difficulty
         if (schwierigkeit) {
             const parsedDifficulty = parseInt(schwierigkeit)
             if (!isNaN(parsedDifficulty)) {
@@ -198,7 +210,7 @@ export class UebernatuerlichDialog extends CombatDialog {
         const icon = '⚡'
 
         // Base energy cost
-        let originalCost = sanitizeEnergyCost(this.item.system.kosten) || 0
+        let originalCost = this.getEffectiveSpellProfile().cost
         if (this.energy_override != null) {
             originalCost = this.energy_override
         }
@@ -237,7 +249,7 @@ export class UebernatuerlichDialog extends CombatDialog {
             })
         }
 
-        const difficulty = +this.item.system.schwierigkeit
+        const difficulty = this.getEffectiveSpellProfile().difficulty
         const isNonStandardDifficulty = isNaN(difficulty) || !difficulty
 
         return {
@@ -300,7 +312,7 @@ export class UebernatuerlichDialog extends CombatDialog {
 
         const hasVerbotenePforten = this.hasVerbotenePfortenAccess()
 
-        const difficulty = +this.item.system.schwierigkeit
+        const difficulty = this.getEffectiveSpellProfile().difficulty
         const isNonStandardDifficulty = isNaN(difficulty) || !difficulty
 
         return {
@@ -321,6 +333,7 @@ export class UebernatuerlichDialog extends CombatDialog {
             set_energy_cost: this.set_energy_cost,
             ilarisSituationControls: this.ilarisSituationControls,
             armedInputs: this._getArmedInputs(),
+            ...this._getSpellModificationTemplateContext(),
         }
     }
 
@@ -334,7 +347,7 @@ export class UebernatuerlichDialog extends CombatDialog {
             Number(this.element.querySelector('input[name="xd20"]:checked')?.value) || 0
         xd20_choice = xd20_choice == 0 ? 1 : 3
         let diceFormula = this.getDiceFormula(xd20_choice)
-        await this.manoeverAuswaehlen()
+        if ((await this.manoeverAuswaehlen()) === false) return
         await this.updateManoeverMods()
         this.updateStatusMods()
 
@@ -349,7 +362,7 @@ export class UebernatuerlichDialog extends CombatDialog {
         // Parse difficulty from item's schwierigkeit
         let difficulty = null
         let additionalText = ''
-        const schwierigkeit = this.item.system.schwierigkeit
+        const schwierigkeit = this.getEffectiveSpellProfile().difficulty
         if (schwierigkeit) {
             const parsedDifficulty = parseInt(schwierigkeit)
             if (!isNaN(parsedDifficulty)) {
@@ -358,6 +371,7 @@ export class UebernatuerlichDialog extends CombatDialog {
                 additionalText = `\n${schwierigkeit}`
             }
         }
+        additionalText += this.getEffectiveSpellProfileText()
 
         const rollResult = await evaluate_roll_with_crit(
             formula,
@@ -394,13 +408,16 @@ export class UebernatuerlichDialog extends CombatDialog {
         super._updateSchipsStern()
 
         // Fire-and-forget pre-effects on success
-        if (isSuccess && this.item.system.preEffects?.length > 0) {
-            await applyPreEffects(rollResult, this, this.armedInputValues)
+        if (isSuccess && this.getEffectiveSpellModificationContext().preEffects.length > 0) {
+            await applyPreEffects(rollResult, this, this.armedInputValues, {
+                preEffects: this.getEffectiveSpellModificationContext().preEffects,
+                spellModificationId: this.getSelectedSpellModificationId(),
+            })
         }
     }
 
     async _energieAbrechnenKlick(isSuccess) {
-        await this.manoeverAuswaehlen()
+        if ((await this.manoeverAuswaehlen()) === false) return
         await this.updateManoeverMods()
         // Initialize and check energy values
         await this.initializeEnergyValues()
@@ -408,8 +425,11 @@ export class UebernatuerlichDialog extends CombatDialog {
         await this.applyEnergyCost(isSuccess, this.is16OrHigher)
 
         // Fire-and-forget pre-effects for non-standard difficulty spells
-        if (isSuccess && this.item.system.preEffects?.length > 0) {
-            await applyPreEffects({ success: true }, this, this.armedInputValues)
+        if (isSuccess && this.getEffectiveSpellModificationContext().preEffects.length > 0) {
+            await applyPreEffects({ success: true }, this, this.armedInputValues, {
+                preEffects: this.getEffectiveSpellModificationContext().preEffects,
+                spellModificationId: this.getSelectedSpellModificationId(),
+            })
         }
 
         // If not enough resources, show error
@@ -484,7 +504,7 @@ export class UebernatuerlichDialog extends CombatDialog {
         // Calculate cost based on success
         let cost = isSuccess
             ? this.mod_energy
-            : Math.ceil(sanitizeEnergyCost(this.item.system.kosten) / costModifier)
+            : Math.ceil(this.getEffectiveSpellProfile().cost / costModifier)
 
         // Apply all cost modifications from advantages and styles
         cost = hardcoded.calculateModifiedCost(
@@ -543,6 +563,12 @@ export class UebernatuerlichDialog extends CombatDialog {
      * Parse maneuver selections from the dialog form.
      */
     async manoeverAuswaehlen() {
+        this._updateSpellModificationSelection()
+        const spellModificationContext = this.getEffectiveSpellModificationContext()
+        if (!spellModificationContext.valid) {
+            ui.notifications.error(spellModificationContext.errors.join(' '))
+            return false
+        }
         // Ensure manoever exists
         if (!this.item.system.manoever) {
             this.item.system.manoever = ILARIS.manoever_ueber
@@ -587,11 +613,12 @@ export class UebernatuerlichDialog extends CombatDialog {
         manoever.mod.selected =
             Number(this.element.querySelector(`#modifikator-${this.dialogId}`)?.value) || 0 // Modifikator
         await super.manoeverAuswaehlen()
+        return true
     }
 
     _getArmedInputs() {
         const inputs = []
-        for (const preEffect of Object.values(this.item.system.preEffects || {})) {
+        for (const preEffect of this.getEffectiveSpellModificationContext().preEffects) {
             for (const input of preEffect?.armedCombat?.inputs || []) {
                 if (input?.key && !inputs.some((entry) => entry.key === input.key))
                     inputs.push(input)
@@ -690,12 +717,17 @@ export class UebernatuerlichDialog extends CombatDialog {
 
     async updateManoeverMods() {
         this._updateIlarisSituationSelection()
+        const spellModificationContext = this.getEffectiveSpellModificationContext()
+        this.spellModificationContext = spellModificationContext
         let manoever = this.item.system.manoever
 
         let mod_at = 0
         let mod_vt = 0
         let mod_dm = 0
-        let mod_energy = sanitizeEnergyCost(this.item.system.kosten)
+        let mod_energy = spellModificationContext.profile.cost
+        this.energy_override = spellModificationContext.selectedForms.length
+            ? spellModificationContext.profile.cost
+            : null
         if (this.set_energy_cost?.value != null) {
             mod_energy = this.set_energy_cost.value
             this.energy_override = this.set_energy_cost.value
@@ -881,6 +913,65 @@ export class UebernatuerlichDialog extends CombatDialog {
         this.fumble_val = fumble_val
         this.damageType = damageType
         this.trueDamage = trueDamage
+    }
+
+    getEffectiveSpellProfileText() {
+        const context = this.getEffectiveSpellModificationContext()
+        if (!context.selectedForms.length) return ''
+        const profile = context.profile
+        const formNames = context.selectedForms.map((form) => form.name).join(', ')
+        const descriptions = context.selectedForms
+            .map((form) => form.description)
+            .filter(Boolean)
+            .join('\n')
+        return `\nZaubermodifikation: ${formNames}\nZiel: ${profile.target || this.item.system.ziel}\nReichweite: ${profile.range || this.item.system.reichweite}\nWirkungsdauer: ${profile.duration || this.item.system.wirkungsdauer}${profile.permanentCost ? `\nPermanente Kosten: ${profile.permanentCost}` : ''}${descriptions ? `\nWirkung: ${descriptions}` : ''}`
+    }
+
+    _updateSpellModificationSelection() {
+        if (!this.element?.querySelectorAll) return
+        this.selectedSpellModificationIds = Array.from(
+            this.element.querySelectorAll('.spell-modification:checked'),
+        )
+            .map((input) => input.value)
+            .filter(Boolean)
+        this.spellModificationContext = resolveSpellModificationContext(
+            this.item,
+            this.selectedSpellModificationIds,
+        )
+    }
+
+    getEffectiveSpellModificationContext() {
+        this.spellModificationContext ??= resolveSpellModificationContext(
+            this.item,
+            this.selectedSpellModificationIds,
+        )
+        return this.spellModificationContext
+    }
+
+    getEffectiveSpellProfile() {
+        return this.getEffectiveSpellModificationContext().profile
+    }
+
+    getSelectedSpellModificationId() {
+        return this.getEffectiveSpellModificationContext().selectedForms.at(-1)?.id || ''
+    }
+
+    _getSpellModificationTemplateContext() {
+        const { groups, modifications } = normalizeSpellModifications(this.item.system)
+        const selectedIds = this.selectedSpellModificationIds
+        return {
+            spellModificationGroups: groups.map((group) => ({
+                ...group,
+                forms: modifications
+                    .filter((form) => form.group === group.id)
+                    .map((form) => ({ ...form, selected: selectedIds.includes(form.id) })),
+            })),
+            ungroupedSpellModifications: modifications
+                .filter((form) => !form.group)
+                .map((form) => ({ ...form, selected: selectedIds.includes(form.id) })),
+            spellModificationProfile: this.getEffectiveSpellProfile(),
+            spellModificationErrors: this.getEffectiveSpellModificationContext().errors,
+        }
     }
 
     getIlarisSituationTags() {

--- a/scripts/combat/templates/dialogs/uebernatuerlich.hbs
+++ b/scripts/combat/templates/dialogs/uebernatuerlich.hbs
@@ -36,6 +36,35 @@
             <input type="number" name="ilaris-armed-input-{{key}}" value="{{default}}" min="{{min}}" max="{{max}}" step="1" />
         </div>
         {{/each}}
+        {{#if (or spellModificationGroups.length ungroupedSpellModifications.length)}}
+        <hr />
+        <section class="spell-modifications-section">
+            <h3>Zaubermodifikationen</h3>
+            {{#each spellModificationGroups as |group|}}
+            <fieldset class="spell-modification-group">
+                <legend>{{group.label}}{{#if group.required}} <span class="required">*</span>{{/if}}</legend>
+                {{#each group.forms as |form|}}
+                <label class="spell-modification-option" data-tooltip="{{form.description}}">
+                    <input class="spell-modification" type="radio" name="spell-modification-group-{{group.id}}" value="{{form.id}}" {{checked form.selected}} />
+                    <strong>{{form.name}}</strong>
+                    {{#if form.description}}<span class="description">{{form.description}}</span>{{/if}}
+                </label>
+                {{/each}}
+            </fieldset>
+            {{/each}}
+            {{#each ungroupedSpellModifications as |form|}}
+            <label class="spell-modification-option" data-tooltip="{{form.description}}">
+                <input class="spell-modification" type="checkbox" name="spell-modification-{{form.id}}" value="{{form.id}}" {{checked form.selected}} />
+                <strong>{{form.name}}</strong>
+                {{#if form.description}}<span class="description">{{form.description}}</span>{{/if}}
+            </label>
+            {{/each}}
+            {{#if spellModificationErrors.length}}
+            <p class="notification error">{{spellModificationErrors.[0]}}</p>
+            {{/if}}
+            <p class="description"><strong>Effektives Profil:</strong> Schwierigkeit {{spellModificationProfile.difficulty}}, Kosten {{spellModificationProfile.cost}}{{#if spellModificationProfile.target}}, Ziel {{spellModificationProfile.target}}{{/if}}{{#if spellModificationProfile.range}}, Reichweite {{spellModificationProfile.range}}{{/if}}{{#if spellModificationProfile.duration}}, Dauer {{spellModificationProfile.duration}}{{/if}}{{#if spellModificationProfile.permanentCost}}, Permanente Kosten {{spellModificationProfile.permanentCost}}{{/if}}</p>
+        </section>
+        {{/if}}
         {{#if (or ilarisSituationControls.boolean.length ilarisSituationControls.exclusive.length)}}
         <hr />
         <div>

--- a/scripts/effects/pre-effects/_spec/pre-effects-processor.spec.js
+++ b/scripts/effects/pre-effects/_spec/pre-effects-processor.spec.js
@@ -75,6 +75,37 @@ describe('toArray', () => {
 })
 
 describe('pre-effect processor', () => {
+    it('uses an explicit form list instead of source pre-effects and records form provenance', async () => {
+        const caster = createTargetActor({ id: 'caster-id', uuid: 'Actor.caster' })
+        global.game.actors = { get: jest.fn((id) => (id === caster.id ? caster : undefined)) }
+        const spell = {
+            name: 'Fortifex',
+            uuid: 'Item.fortifex',
+            system: {
+                preEffects: [
+                    { baseDuration: 2, changes: [{ key: 'system.base', type: 'add', value: '1' }] },
+                ],
+            },
+        }
+        const replacement = {
+            baseDuration: 4,
+            changes: [{ key: 'system.replacement', type: 'add', value: '2' }],
+        }
+
+        await applyPreEffects(
+            { success: true },
+            { item: spell, actor: caster, selectedActors: [{ actorId: caster.id }], speaker: {} },
+            {},
+            { preEffects: [replacement], spellModificationId: 'schimmernder-schild' },
+        )
+
+        const created = global.ActiveEffect.createDocuments.mock.calls[0][0][0]
+        expect(created.changes).toEqual([
+            expect.objectContaining({ key: 'system.replacement', value: '2' }),
+        ])
+        expect(created.flags.ilaris.spellModificationId).toBe('schimmernder-schild')
+    })
+
     it('routes a canonical condition pre-effect to one status-bearing condition effect', async () => {
         global.CONFIG.statusEffects = {
             Position4: {
@@ -505,7 +536,12 @@ describe('pre-effect processor', () => {
                 maechtigeMagieQs: 0,
             }
 
-            await applyPreEffects({ success: true }, dialog)
+            await applyPreEffects(
+                { success: true },
+                dialog,
+                {},
+                { spellModificationId: 'shield-form' },
+            )
             await applyPreEffects({ success: true }, dialog)
 
             for (const target of [firstTarget, secondTarget]) {
@@ -531,6 +567,11 @@ describe('pre-effect processor', () => {
                 ).toBe(2)
             }
             expect(global.ActiveEffect.createDocuments).toHaveBeenCalledTimes(4)
+            expect(
+                global.ActiveEffect.createDocuments.mock.calls[0][0][0].flags.ilaris,
+            ).toMatchObject({
+                spellModificationId: 'shield-form',
+            })
         },
     )
 

--- a/scripts/effects/pre-effects/pre-effects-processor.js
+++ b/scripts/effects/pre-effects/pre-effects-processor.js
@@ -198,6 +198,7 @@ export async function applyPreEffects(rollResult, dialog, armedInputValues = {},
                     armedInputValues,
                     sourceType,
                     triggeringRollTotal,
+                    context.spellModificationId || '',
                 )
                 continue
             }
@@ -214,6 +215,7 @@ export async function applyPreEffects(rollResult, dialog, armedInputValues = {},
                     maechtigeQs,
                     preEffectIndex,
                     applicationId,
+                    spellModificationId: context.spellModificationId || '',
                 })
             } else if (preEffect.instant) {
                 await applyInstantPreEffect(targetActor, preEffect, maechtigeQs, speaker)
@@ -229,6 +231,7 @@ export async function applyPreEffects(rollResult, dialog, armedInputValues = {},
                     applicationId,
                     armedInputValues,
                     sourceType,
+                    context.spellModificationId || '',
                 )
             }
         }
@@ -249,6 +252,7 @@ async function sendResistPromptForEffect(
     armedInputValues,
     sourceType,
     triggeringRollTotal,
+    spellModificationId,
 ) {
     const serialized = {
         ...preEffect,
@@ -262,6 +266,7 @@ async function sendResistPromptForEffect(
         applicationId,
         armedInputValues,
         sourceType,
+        spellModificationId,
         ...(Number.isFinite(triggeringRollTotal) ? { triggeringRollTotal } : {}),
     }
     await sendResistPrompt(targetActor, serialized, spellItem.name, speaker)
@@ -304,6 +309,7 @@ export async function createActiveEffectFromPreEffect(
     applicationId = foundry.utils.randomID(),
     armedInputValues = {},
     sourceType = 'uebernatuerlich',
+    spellModificationId = '',
 ) {
     let payload
     try {
@@ -382,6 +388,7 @@ export async function createActiveEffectFromPreEffect(
                 fertigkeiten: spellItem.system?.fertigkeiten || '',
                 preEffectIndex,
                 applicationId,
+                spellModificationId,
             },
         },
     }

--- a/scripts/effects/pre-effects/resist-handler.js
+++ b/scripts/effects/pre-effects/resist-handler.js
@@ -284,6 +284,7 @@ async function applyPreEffectFromResist(preEffectData) {
         preEffectData.applicationId,
         preEffectData.armedInputValues || {},
         preEffectData.sourceType || 'uebernatuerlich',
+        preEffectData.spellModificationId || '',
     )
 }
 
@@ -357,6 +358,7 @@ async function applyDiminishedEffect(preEffectData) {
         preEffectData.applicationId,
         preEffectData.armedInputValues || {},
         preEffectData.sourceType || 'uebernatuerlich',
+        preEffectData.spellModificationId || '',
     )
 }
 

--- a/scripts/effects/pre-effects/summoned-items.js
+++ b/scripts/effects/pre-effects/summoned-items.js
@@ -50,6 +50,7 @@ export async function summonItemFromPreEffect({
     maechtigeQs,
     preEffectIndex,
     applicationId,
+    spellModificationId = '',
 }) {
     const config = preEffect.summonItem
     if (!config?.sourceUuid) return null
@@ -119,6 +120,7 @@ export async function summonItemFromPreEffect({
                     summonedItemId: clone.id,
                     preEffectIndex,
                     applicationId,
+                    spellModificationId,
                 },
             },
         }

--- a/scripts/effects/utils/ilaris-modifier-resolver.js
+++ b/scripts/effects/utils/ilaris-modifier-resolver.js
@@ -116,6 +116,7 @@ function modifierMatchesContext(modifier, context) {
     return (
         selectorMatches(selector.fertigkeit, context.fertigkeit) &&
         selectorMatches(selector.talent, context.talent) &&
+        selectorMatches(selector.attribute, context.attributes) &&
         selectorMatches(selector.situation, context.situation)
     )
 }

--- a/scripts/items/_spec/combat.spec.js
+++ b/scripts/items/_spec/combat.spec.js
@@ -71,6 +71,19 @@ describe('CombatItem', () => {
     })
 
     describe('_parseModifikationen', () => {
+        it('keeps prose parsing as a legacy fallback but suppresses it for structured forms', () => {
+            combatItem.system.modifikationen = 'Miasmafaxius (-4, 8 AsP)'
+            combatItem.manoever = []
+            combatItem.system.spellModifications = []
+            combatItem._addLegacySpellModificationManeuvers()
+            expect(combatItem.manoever).toHaveLength(1)
+
+            combatItem.manoever = []
+            combatItem.system.spellModifications = [{ id: 'miasmafaxius' }]
+            combatItem._addLegacySpellModificationManeuvers()
+            expect(combatItem.manoever).toEqual([])
+        })
+
         it('should parse complex modification string with multiple modifications', () => {
             const modificationString =
                 'Schutz vor Übelkeit (–4; auch ungefährliche, aber unangenehme Inhalte wie Salz im Meerwasser werden entfernt.)\nSchutz vor Vergiftung (–4, Wirkungsdauer 8 Stunden; du reinigst auch alles, was dem Essen hinzugefügt wird.)'

--- a/scripts/items/data/_spec/spell-modifications.spec.js
+++ b/scripts/items/data/_spec/spell-modifications.spec.js
@@ -1,0 +1,122 @@
+import {
+    normalizeSpellModifications,
+    resolveSpellModificationContext,
+} from '../spell-modifications.js'
+
+const item = (system) => ({ system })
+
+describe('structured spell modifications', () => {
+    const baseSystem = {
+        schwierigkeit: '12',
+        kosten: '4 AsP',
+        ziel: 'Zone',
+        reichweite: '8 Schritt',
+        wirkungsdauer: '16 Initiativphasen',
+        preEffects: [{ id: 'base' }],
+    }
+
+    test('normalizes malformed fields and defaults omitted mode to inherit', () => {
+        expect(normalizeSpellModifications({ spellModifications: { bad: true } })).toEqual({
+            groups: [],
+            modifications: [],
+        })
+
+        const normalized = normalizeSpellModifications({
+            spellModificationGroups: [{ id: 'form', label: 'Form', required: true }],
+            spellModifications: [{ id: 'faxius', name: 'Miasmafaxius', group: 'form' }],
+        })
+        expect(normalized.modifications[0]).toMatchObject({ id: 'faxius', effectMode: 'inherit' })
+    })
+
+    test('requires exactly one member of a required group', () => {
+        const source = item({
+            ...baseSystem,
+            spellModificationGroups: [{ id: 'attribute', required: true }],
+            spellModifications: [
+                { id: 'ff', name: 'FF', group: 'attribute' },
+                { id: 'ge', name: 'GE', group: 'attribute' },
+            ],
+        })
+
+        expect(resolveSpellModificationContext(source, []).valid).toBe(false)
+        expect(resolveSpellModificationContext(source, ['ff', 'ge']).valid).toBe(false)
+        expect(resolveSpellModificationContext(source, ['ff']).valid).toBe(true)
+    })
+
+    test('composes profile overrides and all effect modes deterministically', () => {
+        const source = item({
+            ...baseSystem,
+            spellModifications: [
+                {
+                    id: 'inherit',
+                    profile: {
+                        difficulty: -4,
+                        cost: { mode: 'set', value: 8 },
+                        target: 'Einzelperson',
+                    },
+                },
+                { id: 'extend', effectMode: 'extend', preEffects: [{ id: 'extra' }] },
+                { id: 'replace', effectMode: 'replace', preEffects: [{ id: 'replacement' }] },
+            ],
+        })
+
+        const inherited = resolveSpellModificationContext(source, ['inherit'])
+        expect(inherited.profile).toMatchObject({ difficulty: 8, cost: 8, target: 'Einzelperson' })
+        expect(inherited.preEffects).toEqual([{ id: 'base' }])
+
+        expect(resolveSpellModificationContext(source, ['extend']).preEffects).toEqual([
+            { id: 'base' },
+            { id: 'extra' },
+        ])
+        expect(resolveSpellModificationContext(source, ['replace']).preEffects).toEqual([
+            { id: 'replacement' },
+        ])
+    })
+
+    test('rejects unknown ids and conflicting independent set overrides', () => {
+        const source = item({
+            ...baseSystem,
+            spellModifications: [
+                { id: 'eight', profile: { cost: { mode: 'set', value: 8 } } },
+                { id: 'sixteen', profile: { cost: { mode: 'set', value: 16 } } },
+            ],
+        })
+        expect(resolveSpellModificationContext(source, ['unknown']).valid).toBe(false)
+        expect(resolveSpellModificationContext(source, ['eight', 'sixteen']).valid).toBe(false)
+    })
+
+    test('keeps optional forms independent and leaves legacy-only Items untouched', () => {
+        const source = item({
+            ...baseSystem,
+            modifikationen: 'Alte Textmodifikation (-4)',
+            spellModificationGroups: [{ id: 'required', required: true }],
+            spellModifications: [
+                { id: 'required-form', group: 'required' },
+                { id: 'optional-form', profile: { difficulty: -2 } },
+            ],
+        })
+
+        expect(
+            resolveSpellModificationContext(source, ['required-form', 'optional-form']),
+        ).toMatchObject({
+            valid: true,
+            profile: { difficulty: 10 },
+        })
+        expect(resolveSpellModificationContext(item(baseSystem), [])).toMatchObject({
+            valid: true,
+            selectedForms: [],
+            preEffects: [{ id: 'base' }],
+        })
+    })
+
+    test('requires one anti-magic preset form and accepts any one of its four choices', () => {
+        const source = item({ ...baseSystem, spellModificationPreset: 'antiMagic' })
+
+        expect(resolveSpellModificationContext(source, []).valid).toBe(false)
+        expect(resolveSpellModificationContext(source, ['zauber-aufheben'])).toMatchObject({
+            valid: true,
+            selectedForms: [expect.objectContaining({ effectMode: 'replace' })],
+            profile: { permanentCost: 'Halbe Basiskosten des Zielzaubers' },
+        })
+    })
+})

--- a/scripts/items/data/combat-item.js
+++ b/scripts/items/data/combat-item.js
@@ -357,9 +357,7 @@ export class CombatItem extends IlarisItem {
                 }
             })
 
-            // Parse modifikationen string and add dynamic maneuvers
-            const dynamicManeuvers = this._parseModifikationen(this.system.modifikationen)
-            this.manoever.push(...dynamicManeuvers)
+            this._addLegacySpellModificationManeuvers()
         }
         if ('liturgie' === this.type) {
             this.system.manoever = foundry.utils.mergeObject(
@@ -378,9 +376,7 @@ export class CombatItem extends IlarisItem {
                 }
             })
 
-            // Parse modifikationen string and add dynamic maneuvers
-            const dynamicManeuvers = this._parseModifikationen(this.system.modifikationen)
-            this.manoever.push(...dynamicManeuvers)
+            this._addLegacySpellModificationManeuvers()
         }
         if ('anrufung' === this.type) {
             this.system.manoever = foundry.utils.mergeObject(
@@ -400,9 +396,21 @@ export class CombatItem extends IlarisItem {
             //     }
             // })
 
-            // Parse modifikationen string and add dynamic maneuvers
-            const dynamicManeuvers = this._parseModifikationen(this.system.modifikationen)
-            this.manoever.push(...dynamicManeuvers)
+            this._addLegacySpellModificationManeuvers()
         }
+    }
+
+    /** Preserve prose parsing only until an Item has real structured spell forms. */
+    _addLegacySpellModificationManeuvers() {
+        const structuredForms = this.system.spellModifications
+        const hasStructuredForms =
+            this.system.spellModificationPreset ||
+            (Array.isArray(structuredForms)
+                ? structuredForms.length > 0
+                : structuredForms && typeof structuredForms === 'object'
+                  ? Object.keys(structuredForms).length > 0
+                  : false)
+        if (hasStructuredForms) return
+        this.manoever.push(...this._parseModifikationen(this.system.modifikationen))
     }
 }

--- a/scripts/items/data/spell-modifications.js
+++ b/scripts/items/data/spell-modifications.js
@@ -1,0 +1,236 @@
+/**
+ * Pure, dialog-safe resolution for persisted supernatural spell forms.
+ * Selections are intentionally never written back to the source Item.
+ */
+
+function toArray(value) {
+    if (Array.isArray(value)) return value
+    if (value && typeof value === 'object') return Object.values(value)
+    return []
+}
+
+function clone(value) {
+    if (value === undefined) return undefined
+    if (globalThis.foundry?.utils?.deepClone) return foundry.utils.deepClone(value)
+    return JSON.parse(JSON.stringify(value ?? null))
+}
+
+function asText(value) {
+    return typeof value === 'string' ? value.trim() : ''
+}
+
+function numeric(value, fallback = 0) {
+    const parsed = Number.parseInt(value, 10)
+    return Number.isFinite(parsed) ? parsed : fallback
+}
+
+function normalizeProfile(profile) {
+    const source = profile && typeof profile === 'object' ? profile : {}
+    const cost = source.cost && typeof source.cost === 'object' ? source.cost : {}
+    const costMode = cost.mode === 'set' || cost.mode === 'add' ? cost.mode : ''
+    return {
+        difficulty: numeric(source.difficulty),
+        cost:
+            costMode && Number.isFinite(Number(cost.value))
+                ? { mode: costMode, value: Number(cost.value) }
+                : null,
+        permanentCost: asText(source.permanentCost),
+        target: asText(source.target),
+        range: asText(source.range),
+        duration: asText(source.duration),
+    }
+}
+
+const ANTIMAGIC_PRESET = Object.freeze({
+    groups: [{ id: 'antiMagicForm', label: 'Antimagieform', required: true }],
+    modifications: [
+        {
+            id: 'gegenzauber',
+            name: 'Gegenzauber',
+            description:
+                'Konterprobe (12) gegen einen Zauber in Vorbereitung. Die weitere Abwicklung erfolgt durch Spielleitung und Spieler.',
+            profile: {
+                difficulty: 0,
+                cost: { mode: 'set', value: 4 },
+                target: 'Zauber in Vorbereitung',
+                range: '16 Schritt',
+                duration: 'augenblicklich',
+            },
+        },
+        {
+            id: 'magie-unterdruecken',
+            name: 'Magie unterdrücken',
+            description:
+                'Unterdrückt zukünftige Zauber der Fertigkeit in einer Zone. Der Malus und die Zone werden durch Spielleitung und Spieler verwaltet.',
+            profile: {
+                difficulty: 0,
+                cost: { mode: 'set', value: 8 },
+                target: 'Zone',
+                range: '8 Schritt',
+                duration: '1 Stunde',
+            },
+        },
+        {
+            id: 'zauber-aufheben',
+            name: 'Zauber aufheben',
+            description:
+                'Konterprobe (12) gegen einen bereits gewirkten Zauber ohne gAsP. Die Aufhebung wird durch Spielleitung und Spieler verwaltet.',
+            profile: {
+                difficulty: 0,
+                target: 'Zauber',
+                range: '8 Schritt',
+                duration: 'augenblicklich',
+            },
+        },
+        {
+            id: 'wesenheit-bannen',
+            name: 'Wesenheit bannen',
+            description:
+                'Bannung einer beschworenen Wesenheit ohne gAsP. Schwierigkeit und Ergebnis werden durch Spielleitung und Spieler verwaltet.',
+            profile: {
+                difficulty: 0,
+                target: 'beschworenes Wesen',
+                range: '8 Schritt',
+                duration: 'augenblicklich',
+            },
+        },
+    ],
+})
+
+const ANTIMAGIC_RULE_TEXT = Object.freeze({
+    gegenzauber:
+        'Vorbereitung 0 Aktionen. Konterprobe (12) gegen einen Zauber in Vorbereitung. Die weitere Abwicklung erfolgt durch Spielleitung und Spieler.',
+    'magie-unterdruecken':
+        'Vorbereitung 16 Aktionen. Unterdr\u00fcckt zuk\u00fcnftige Zauber der Fertigkeit in einer Zone. Der Malus und die Zone werden durch Spielleitung und Spieler verwaltet.',
+    'zauber-aufheben':
+        'Vorbereitung 16 Aktionen. Konterprobe (12) gegen einen bereits gewirkten Zauber. Die Aufhebung wird durch Spielleitung und Spieler verwaltet.',
+    'wesenheit-bannen':
+        'Vorbereitung 16 Aktionen. Bannung einer beschworenen Wesenheit. Schwierigkeit und Ergebnis werden durch Spielleitung und Spieler verwaltet.',
+})
+
+const ANTIMAGIC_PROFILE_EXTRAS = Object.freeze({
+    'zauber-aufheben': { permanentCost: 'Halbe Basiskosten des Zielzaubers' },
+    'wesenheit-bannen': { permanentCost: 'Halbe Basiskosten der Beschw\u00f6rung' },
+})
+
+/** Normalize Foundry ObjectField values to structurally safe form data. */
+export function normalizeSpellModifications(system = {}) {
+    const preset = system.spellModificationPreset === 'antiMagic' ? ANTIMAGIC_PRESET : null
+    const groups = toArray(preset?.groups || system.spellModificationGroups)
+        .filter((group) => group && typeof group === 'object' && asText(group.id))
+        .map((group) => ({
+            id: asText(group.id),
+            label: asText(group.label) || asText(group.id),
+            required: Boolean(group.required),
+        }))
+
+    const knownGroupIds = new Set(groups.map((group) => group.id))
+    const ids = new Set()
+    const modifications = toArray(preset?.modifications || system.spellModifications)
+        .filter((modification) => modification && typeof modification === 'object')
+        .map((modification) => ({
+            id: asText(modification.id),
+            name: asText(modification.name),
+            description: asText(
+                preset === ANTIMAGIC_PRESET
+                    ? ANTIMAGIC_RULE_TEXT[modification.id] || modification.description
+                    : modification.description,
+            ),
+            group: preset === ANTIMAGIC_PRESET ? 'antiMagicForm' : asText(modification.group),
+            effectMode: ['inherit', 'extend', 'replace'].includes(modification.effectMode)
+                ? modification.effectMode
+                : preset === ANTIMAGIC_PRESET
+                  ? 'replace'
+                  : 'inherit',
+            profile: normalizeProfile({
+                ...modification.profile,
+                ...(preset === ANTIMAGIC_PRESET ? ANTIMAGIC_PROFILE_EXTRAS[modification.id] : {}),
+            }),
+            preEffects: toArray(clone(modification.preEffects)),
+        }))
+        .filter((modification) => {
+            if (!modification.id || ids.has(modification.id)) return false
+            ids.add(modification.id)
+            return !modification.group || knownGroupIds.has(modification.group)
+        })
+
+    return { groups, modifications }
+}
+
+function baseProfile(system = {}) {
+    return {
+        difficulty: numeric(system.schwierigkeit),
+        cost: numeric(system.kosten),
+        permanentCost: '',
+        target: asText(system.ziel),
+        range: asText(system.reichweite),
+        duration: asText(system.wirkungsdauer),
+    }
+}
+
+function addError(errors, message) {
+    if (!errors.includes(message)) errors.push(message)
+}
+
+/**
+ * Resolve selected form ids against an Item without mutating it.
+ * @returns {{valid: boolean, errors: string[], selectedForms: object[], profile: object, preEffects: object[]}}
+ */
+export function resolveSpellModificationContext(item, selectedIds = []) {
+    const system = item?.system || {}
+    const { groups, modifications } = normalizeSpellModifications(system)
+    const errors = []
+    const uniqueIds = [...new Set(toArray(selectedIds).map(asText).filter(Boolean))]
+    const byId = new Map(modifications.map((modification) => [modification.id, modification]))
+    const selectedForms = []
+    for (const id of uniqueIds) {
+        const form = byId.get(id)
+        if (!form) addError(errors, `Unbekannte Zaubermodifikation: ${id}`)
+        else selectedForms.push(form)
+    }
+
+    for (const group of groups) {
+        const selectedInGroup = selectedForms.filter((form) => form.group === group.id)
+        if (selectedInGroup.length > 1)
+            addError(errors, `Für ${group.label} darf nur eine Modifikation gewählt werden.`)
+        if (group.required && selectedInGroup.length !== 1)
+            addError(errors, `Für ${group.label} muss genau eine Modifikation gewählt werden.`)
+    }
+
+    const profile = baseProfile(system)
+    const overrideOwners = new Map()
+    let preEffects = toArray(clone(system.preEffects))
+    for (const form of modifications.filter((candidate) => uniqueIds.includes(candidate.id))) {
+        profile.difficulty += form.profile.difficulty
+        if (form.profile.cost) {
+            if (form.profile.cost.mode === 'add') profile.cost += form.profile.cost.value
+            else if (overrideOwners.has('cost') && profile.cost !== form.profile.cost.value) {
+                addError(errors, 'Mehrere Zaubermodifikationen setzen unterschiedliche Kosten.')
+            } else {
+                profile.cost = form.profile.cost.value
+                overrideOwners.set('cost', form.id)
+            }
+        }
+        for (const [key, value] of Object.entries({
+            permanentCost: form.profile.permanentCost,
+            target: form.profile.target,
+            range: form.profile.range,
+            duration: form.profile.duration,
+        })) {
+            if (!value) continue
+            if (overrideOwners.has(key) && profile[key] !== value) {
+                addError(
+                    errors,
+                    'Mehrere Zaubermodifikationen überschreiben dieselbe Profilangabe.',
+                )
+                continue
+            }
+            profile[key] = value
+            overrideOwners.set(key, form.id)
+        }
+        if (form.effectMode === 'extend') preEffects.push(...clone(form.preEffects))
+        if (form.effectMode === 'replace') preEffects = clone(form.preEffects)
+    }
+
+    return { valid: errors.length === 0, errors, selectedForms, profile, preEffects }
+}

--- a/scripts/items/model-data/models.js
+++ b/scripts/items/model-data/models.js
@@ -41,6 +41,9 @@ export function createItemTypeDataModels(TypeDataModel, h) {
         pw: h.number(0),
         gruppe: h.number(-1),
         preEffects: h.arrayOfObjects(),
+        spellModifications: h.arrayOfObjects(),
+        spellModificationGroups: h.arrayOfObjects(),
+        spellModificationPreset: h.string(''),
     })
 
     class NahkampfwaffeItemDataModel extends TypeDataModel {

--- a/scripts/items/sheets/_spec/uebernatuerlich-talent.spec.js
+++ b/scripts/items/sheets/_spec/uebernatuerlich-talent.spec.js
@@ -243,3 +243,71 @@ describe('UebernatuerlichTalentSheet Ilaris modifier removal', () => {
         })
     })
 })
+
+describe('UebernatuerlichTalentSheet structured spell forms', () => {
+    it('persists group/form array edits and exposes the nested Pre-Effect authoring controls', async () => {
+        const sheet = new UebernatuerlichTalentSheet()
+        const clickHandlers = []
+        const editor = {
+            addEventListener: jest.fn((_eventName, handler) => clickHandlers.push(handler)),
+        }
+        sheet.element = {
+            querySelector: jest.fn((selector) => {
+                if (selector === '.spell-modification-editor') return editor
+                return null
+            }),
+            querySelectorAll: jest.fn(() => []),
+        }
+        sheet.document = {
+            system: {
+                spellModificationGroups: { 0: { id: 'attribute', label: 'Attribut' } },
+                spellModifications: {
+                    0: { id: 'ff', name: 'FF', preEffects: { 0: { baseDuration: 1 } } },
+                },
+            },
+            update: jest.fn().mockResolvedValue(undefined),
+        }
+        const addGroup = {
+            dataset: {},
+            closest: jest.fn((selector) => {
+                if (selector === 'button') return addGroup
+                if (selector === '.add-spell-modification-group') return addGroup
+                return null
+            }),
+        }
+        const addNestedPreEffect = {
+            dataset: { formIndex: '0' },
+            closest: jest.fn((selector) => {
+                if (selector === 'button') return addNestedPreEffect
+                if (selector === '.add-spell-modification-pre-effect') return addNestedPreEffect
+                return null
+            }),
+        }
+
+        sheet._onRender({}, {})
+        await clickHandlers[0]({ target: addGroup })
+        await clickHandlers[0]({ target: addNestedPreEffect })
+
+        expect(sheet.document.update).toHaveBeenNthCalledWith(1, {
+            'system.spellModificationGroups': [
+                { id: 'attribute', label: 'Attribut' },
+                expect.objectContaining({ id: expect.stringMatching(/^gruppe-/) }),
+            ],
+        })
+        expect(sheet.document.update).toHaveBeenNthCalledWith(2, {
+            'system.spellModifications': [
+                expect.objectContaining({
+                    id: 'ff',
+                    preEffects: [expect.objectContaining({ baseDuration: 1 }), expect.any(Object)],
+                }),
+            ],
+        })
+
+        const template = readFileSync(
+            join(process.cwd(), 'scripts', 'items', 'templates', 'uebernatuerlich_talent.hbs'),
+            'utf8',
+        )
+        expect(template).toContain('spell-modification-editor')
+        expect(template).toContain('add-spell-modification-pre-effect')
+    })
+})

--- a/scripts/items/sheets/uebernatuerlich-talent.js
+++ b/scripts/items/sheets/uebernatuerlich-talent.js
@@ -1,4 +1,4 @@
-import { PreEffectItemSheet } from './pre-effect-item.js'
+import { PreEffectItemSheet, toPreEffectArray } from './pre-effect-item.js'
 
 export class UebernatuerlichTalentSheet extends PreEffectItemSheet {
     /** @override */
@@ -34,6 +34,107 @@ export class UebernatuerlichTalentSheet extends PreEffectItemSheet {
         this.element.querySelector('.generate-pre-effect')?.addEventListener('click', async () => {
             await this.#handleLLMGenerate()
         })
+        this.element
+            .querySelector('.spell-modification-editor')
+            ?.addEventListener('click', (event) => {
+                this.#handleSpellModificationEditorClick(event)
+            })
+    }
+
+    #cloneSpellModifications() {
+        return toPreEffectArray(foundry.utils.deepClone(this.document.system.spellModifications))
+    }
+
+    #cloneSpellModificationGroups() {
+        return toPreEffectArray(
+            foundry.utils.deepClone(this.document.system.spellModificationGroups),
+        )
+    }
+
+    #defaultSpellModification() {
+        return {
+            id: `form-${foundry.utils.randomID(8)}`,
+            name: 'Neue Zaubermodifikation',
+            description: '',
+            group: '',
+            effectMode: 'inherit',
+            profile: {
+                difficulty: 0,
+                cost: { mode: 'add', value: 0 },
+                permanentCost: '',
+                target: '',
+                range: '',
+                duration: '',
+            },
+            preEffects: [],
+        }
+    }
+
+    async #handleSpellModificationEditorClick(event) {
+        const button = event.target.closest('button')
+        if (!button) return
+        const formIndex = Number(button.dataset.formIndex)
+        const groupIndex = Number(button.dataset.groupIndex)
+        const updateForms = async (forms) =>
+            this.document.update({ 'system.spellModifications': forms })
+
+        if (button.closest('.add-spell-modification-group')) {
+            const groups = this.#cloneSpellModificationGroups()
+            groups.push({
+                id: `gruppe-${foundry.utils.randomID(8)}`,
+                label: 'Neue Gruppe',
+                required: false,
+            })
+            await this.document.update({ 'system.spellModificationGroups': groups })
+            return
+        }
+        if (button.closest('.delete-spell-modification-group')) {
+            const groups = this.#cloneSpellModificationGroups()
+            const [removed] = groups.splice(groupIndex, 1)
+            const forms = this.#cloneSpellModifications().map((form) =>
+                form.group === removed?.id ? { ...form, group: '' } : form,
+            )
+            await this.document.update({
+                'system.spellModificationGroups': groups,
+                'system.spellModifications': forms,
+            })
+            return
+        }
+        if (button.closest('.add-spell-modification')) {
+            const forms = this.#cloneSpellModifications()
+            forms.push(this.#defaultSpellModification())
+            await updateForms(forms)
+            return
+        }
+        if (button.closest('.delete-spell-modification')) {
+            const forms = this.#cloneSpellModifications()
+            forms.splice(formIndex, 1)
+            await updateForms(forms)
+            return
+        }
+        if (button.closest('.move-spell-modification')) {
+            const forms = this.#cloneSpellModifications()
+            const targetIndex = formIndex + Number(button.dataset.direction)
+            if (targetIndex < 0 || targetIndex >= forms.length) return
+            ;[forms[formIndex], forms[targetIndex]] = [forms[targetIndex], forms[formIndex]]
+            await updateForms(forms)
+            return
+        }
+        if (button.closest('.add-spell-modification-pre-effect')) {
+            const forms = this.#cloneSpellModifications()
+            if (!forms[formIndex]) return
+            forms[formIndex].preEffects = toPreEffectArray(forms[formIndex].preEffects)
+            forms[formIndex].preEffects.push(this._defaultPreEffect())
+            await updateForms(forms)
+            return
+        }
+        if (button.closest('.delete-spell-modification-pre-effect')) {
+            const forms = this.#cloneSpellModifications()
+            if (!forms[formIndex]) return
+            forms[formIndex].preEffects = toPreEffectArray(forms[formIndex].preEffects)
+            forms[formIndex].preEffects.splice(Number(button.dataset.preEffectIndex), 1)
+            await updateForms(forms)
+        }
     }
 
     /** Call the configured LLM API to generate Pre-Effects for this spell. */

--- a/scripts/items/templates/uebernatuerlich_talent.hbs
+++ b/scripts/items/templates/uebernatuerlich_talent.hbs
@@ -36,6 +36,53 @@
                 <label>Modifikationen:</label>
                 <textarea name="system.modifikationen">{{item.system.modifikationen}}</textarea>
             </div>
+            <section class="spell-modification-editor">
+                <h3>Strukturierte Zaubermodifikationen</h3>
+                <p class="hint">Diese Formen ersetzen nur die automatisch erzeugten Modifikationsmanöver. Der Regeltext oben bleibt erhalten.</p>
+                <button type="button" class="add-spell-modification-group">Gruppe hinzufügen</button>
+                {{#each item.system.spellModificationGroups as |group|}}
+                <fieldset class="spell-modification-group-card">
+                    <legend>Gruppe {{@index}}</legend>
+                    <div class="form-group"><label>ID</label><input type="text" name="system.spellModificationGroups.{{@index}}.id" value="{{group.id}}" /></div>
+                    <div class="form-group"><label>Bezeichnung</label><input type="text" name="system.spellModificationGroups.{{@index}}.label" value="{{group.label}}" /></div>
+                    <label><input type="checkbox" name="system.spellModificationGroups.{{@index}}.required" {{checked group.required}} /> Genau eine Auswahl erforderlich</label>
+                    <button type="button" class="delete-spell-modification-group" data-group-index="{{@index}}">Gruppe löschen</button>
+                </fieldset>
+                {{/each}}
+                <button type="button" class="add-spell-modification">Zaubermodifikation hinzufügen</button>
+                {{#each item.system.spellModifications as |form|}}
+                <fieldset class="spell-modification-card">
+                    <legend>Form {{@index}}: {{form.name}}</legend>
+                    <div class="form-group"><label>ID</label><input type="text" name="system.spellModifications.{{@index}}.id" value="{{form.id}}" /></div>
+                    <div class="form-group"><label>Name</label><input type="text" name="system.spellModifications.{{@index}}.name" value="{{form.name}}" /></div>
+                    <div class="form-group"><label>Beschreibung</label><textarea name="system.spellModifications.{{@index}}.description">{{form.description}}</textarea></div>
+                    <div class="form-group"><label>Gruppe</label><input type="text" name="system.spellModifications.{{@index}}.group" value="{{form.group}}" list="spell-modification-groups" /></div>
+                    <div class="form-group"><label>Effektmodus</label><select name="system.spellModifications.{{@index}}.effectMode"><option value="inherit" {{#if (ifEq form.effectMode "inherit")}}selected{{/if}}>Basis übernehmen</option><option value="extend" {{#if (ifEq form.effectMode "extend")}}selected{{/if}}>Basis erweitern</option><option value="replace" {{#if (ifEq form.effectMode "replace")}}selected{{/if}}>Basis ersetzen</option></select></div>
+                    <h4>Profil</h4>
+                    <div class="form-group"><label>Schwierigkeit</label><input type="number" name="system.spellModifications.{{@index}}.profile.difficulty" value="{{form.profile.difficulty}}" /></div>
+                    <div class="form-group"><label>Kostenmodus</label><select name="system.spellModifications.{{@index}}.profile.cost.mode"><option value="add" {{#if (ifEq form.profile.cost.mode "add")}}selected{{/if}}>Addieren</option><option value="set" {{#if (ifEq form.profile.cost.mode "set")}}selected{{/if}}>Setzen</option></select><input type="number" name="system.spellModifications.{{@index}}.profile.cost.value" value="{{form.profile.cost.value}}" /></div>
+                    <div class="form-group"><label>Permanente Kosten</label><input type="text" name="system.spellModifications.{{@index}}.profile.permanentCost" value="{{form.profile.permanentCost}}" /></div>
+                    <div class="form-group"><label>Ziel</label><input type="text" name="system.spellModifications.{{@index}}.profile.target" value="{{form.profile.target}}" /></div>
+                    <div class="form-group"><label>Reichweite</label><input type="text" name="system.spellModifications.{{@index}}.profile.range" value="{{form.profile.range}}" /></div>
+                    <div class="form-group"><label>Wirkungsdauer</label><input type="text" name="system.spellModifications.{{@index}}.profile.duration" value="{{form.profile.duration}}" /></div>
+                    <h4>Form-Pre-Effects</h4>
+                    <button type="button" class="add-spell-modification-pre-effect" data-form-index="{{@index}}">Pre-Effect hinzufügen</button>
+                    {{#each form.preEffects as |preEffect|}}
+                    <div class="spell-modification-pre-effect-card">
+                        <div class="form-group"><label>Dauer</label><input type="number" name="system.spellModifications.{{@../index}}.preEffects.{{@index}}.baseDuration" value="{{preEffect.baseDuration}}" /></div>
+                        <label><input type="checkbox" name="system.spellModifications.{{@../index}}.preEffects.{{@index}}.instant" {{checked preEffect.instant}} /> Sofortig</label>
+                        <label><input type="checkbox" name="system.spellModifications.{{@../index}}.preEffects.{{@index}}.summonItem.enabled" {{checked preEffect.summonItem.enabled}} /> Gegenstand beschwören</label>
+                        <div class="form-group"><label>Quell-UUID</label><input type="text" name="system.spellModifications.{{@../index}}.preEffects.{{@index}}.summonItem.sourceUuid" value="{{preEffect.summonItem.sourceUuid}}" /></div>
+                        <button type="button" class="delete-spell-modification-pre-effect" data-form-index="{{@../index}}" data-pre-effect-index="{{@index}}">Pre-Effect löschen</button>
+                    </div>
+                    {{/each}}
+                    <button type="button" class="move-spell-modification" data-form-index="{{@index}}" data-direction="-1">↑</button>
+                    <button type="button" class="move-spell-modification" data-form-index="{{@index}}" data-direction="1">↓</button>
+                    <button type="button" class="delete-spell-modification" data-form-index="{{@index}}">Form löschen</button>
+                </fieldset>
+                {{/each}}
+                <datalist id="spell-modification-groups">{{#each item.system.spellModificationGroups}}<option value="{{id}}">{{label}}</option>{{/each}}</datalist>
+            </section>
             <div class="flexrow">
                 <label>Vorbereitung:</label>
                 <input

--- a/scripts/skills/dialogs/fertigkeit.js
+++ b/scripts/skills/dialogs/fertigkeit.js
@@ -237,6 +237,7 @@ export class FertigkeitDialog extends HandlebarsApplicationMixin(ApplicationV2) 
                 target,
                 fertigkeit: this.fertigkeitName,
                 talent,
+                attributes: this.attributeTargets,
                 situation: getIlarisSituationTags(this._getSelectedSituation()),
             }),
         )


### PR DESCRIPTION
Viele Übernatürliche Talente haben Modifikationen, die teils komplett das Talent verändern oder nur kleine Änderungen vornehmen.
Bisher wurden die Modifikationen Property beim Öffnen des Übernatürlichen Dialoges geparst und versucht ein Manöver dafür zu erstellen. Wirklich gut lies sich damit aber nur abdecken, dass man Kosten verändern kann.
Mit den neuen Pre-Effects, die schon sher viele Zauber effektiv abdecken können, hat sich eine Möglichkeit eröffnet wie die Modifikationen gehandhabt werden können.

Sie bilden absofort ihre eigene Sektion im Über Dialog und sind für jeden Zauber konfiguriert und in 3 unterschiedlichen Modi vorhanden, extend, inherit, replace. Die die Über-Talente unterschiedlich stark verändern.

<!-- Wenn dies dein erster PR ist wirf doch zuerst einen Blick in den Workflow-Abschnitt in CONTRIBUTING.md -->

## 📝 PR Template Auswahl

Wähle das passende Template für deinen PR:

- **Für Feature/Bugfix PRs**: Verwende dieses Standard-Template
- **Für Minor Release PRs**: Verwende das [Minor Release Template](https://github.com/pattt333/IlarisFoundryVTT/compare/develop...main?template=pr_minor_release.md)
- **Für Major Release PRs**: Verwende das [Major Release Template](https://github.com/pattt333/IlarisFoundryVTT/compare/develop...main?template=pr_major_release.md)
- **Für Versionsupdate PRs**: Verwende das [Versionsupdate Template](https://github.com/pattt333/IlarisFoundryVTT/compare/develop...main?template=pr_version_update.md)

---

## 📋 Standard PR Informationen
